### PR TITLE
Feat [#3] 홈뷰 스켈레톤 코드 일부 구현

### DIFF
--- a/morib/src/main/java/org/morib/server/api/homeViewApi/controller/HomeViewController.java
+++ b/morib/src/main/java/org/morib/server/api/homeViewApi/controller/HomeViewController.java
@@ -24,4 +24,10 @@ public class HomeViewController {
         return null;
     }
 
+    // 오늘 나의 작업시간 조회
+    @GetMapping("/today")
+    public ResponseEntity<?> fetchTotalTimeOfToday() {
+        homeViewFacade.fetchUserTimer();
+        return null;
+    }
 }

--- a/morib/src/main/java/org/morib/server/api/homeViewApi/controller/HomeViewController.java
+++ b/morib/src/main/java/org/morib/server/api/homeViewApi/controller/HomeViewController.java
@@ -1,4 +1,27 @@
 package org.morib.server.api.homeViewApi.controller;
 
+import lombok.RequiredArgsConstructor;
+import org.morib.server.api.homeViewApi.service.HomeViewFacade;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2")
 public class HomeViewController {
+    private final HomeViewFacade homeViewFacade;
+
+    // 홈뷰 전체 조회
+    @GetMapping("/home")
+    public ResponseEntity<?> fetchHome() {
+        homeViewFacade.fetchHome();
+        return null;
+    }
+
 }

--- a/morib/src/main/java/org/morib/server/api/homeViewApi/service/FetchService.java
+++ b/morib/src/main/java/org/morib/server/api/homeViewApi/service/FetchService.java
@@ -1,4 +1,0 @@
-package org.morib.server.api.homeViewApi.service;
-
-public interface FetchService {
-}

--- a/morib/src/main/java/org/morib/server/api/homeViewApi/service/HomeViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/homeViewApi/service/HomeViewFacade.java
@@ -1,0 +1,22 @@
+package org.morib.server.api.homeViewApi.service;
+
+import lombok.RequiredArgsConstructor;
+import org.morib.server.api.homeViewApi.service.fetch.home.FetchHomeService;
+import org.morib.server.api.homeViewApi.service.fetch.timer.FetchUserTimerService;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class HomeViewFacade {
+
+    private final FetchHomeService fetchHomeService;
+    private final FetchUserTimerService fetchUserTimerService;
+
+    public void fetchHome() {
+        fetchHomeService.execute();
+    }
+
+    public void fetchUserTimer() {
+        fetchUserTimerService.execute();
+    }
+}

--- a/morib/src/main/java/org/morib/server/api/homeViewApi/service/fetch/HomeViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/homeViewApi/service/fetch/HomeViewFacade.java
@@ -1,4 +1,0 @@
-package org.morib.server.api.homeViewApi.service.fetch;
-
-public class HomeViewFacade {
-}

--- a/morib/src/main/java/org/morib/server/api/homeViewApi/service/fetch/home/FetchHomeService.java
+++ b/morib/src/main/java/org/morib/server/api/homeViewApi/service/fetch/home/FetchHomeService.java
@@ -1,0 +1,5 @@
+package org.morib.server.api.homeViewApi.service.fetch.home;
+
+public interface FetchHomeService {
+    void execute();
+}

--- a/morib/src/main/java/org/morib/server/api/homeViewApi/service/fetch/home/FetchHomeServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/api/homeViewApi/service/fetch/home/FetchHomeServiceImpl.java
@@ -1,0 +1,25 @@
+package org.morib.server.api.homeViewApi.service.fetch.home;
+
+import lombok.RequiredArgsConstructor;
+import org.morib.server.domain.category.CategoryReader;
+import org.morib.server.domain.task.TaskReader;
+import org.morib.server.domain.timer.TimerReader;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class FetchHomeServiceImpl implements FetchHomeService {
+
+    private final CategoryReader categoryReader;
+    private final TaskReader taskReader;
+    private final TimerReader timerReader;
+
+    @Override
+    public void execute() {
+        categoryReader.fetchCategories();
+        taskReader.fetch();
+        timerReader.fetch();
+    }
+
+
+}

--- a/morib/src/main/java/org/morib/server/api/homeViewApi/service/fetch/timer/FetchUserTimerService.java
+++ b/morib/src/main/java/org/morib/server/api/homeViewApi/service/fetch/timer/FetchUserTimerService.java
@@ -1,0 +1,5 @@
+package org.morib.server.api.homeViewApi.service.fetch.timer;
+
+public interface FetchUserTimerService {
+    void execute();
+}

--- a/morib/src/main/java/org/morib/server/api/homeViewApi/service/fetch/timer/FetchUserTimerServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/api/homeViewApi/service/fetch/timer/FetchUserTimerServiceImpl.java
@@ -1,0 +1,22 @@
+package org.morib.server.api.homeViewApi.service.fetch.timer;
+
+import lombok.RequiredArgsConstructor;
+import org.morib.server.domain.task.TaskReader;
+import org.morib.server.domain.timer.TimerAggregator;
+import org.morib.server.domain.timer.TimerReader;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class FetchUserTimerServiceImpl implements FetchUserTimerService{
+    private final TaskReader taskReader;
+    private final TimerReader timerReader;
+    private final TimerAggregator timerAggregator;
+
+    @Override
+    public void execute() {
+        taskReader.fetch();
+        timerReader.fetch();
+        timerAggregator.aggregate();
+    }
+}

--- a/morib/src/main/java/org/morib/server/domain/category/Category.java
+++ b/morib/src/main/java/org/morib/server/domain/category/Category.java
@@ -1,4 +1,0 @@
-package org.morib.server.domain.category;
-
-public class Category {
-}

--- a/morib/src/main/java/org/morib/server/domain/category/CategoryReader.java
+++ b/morib/src/main/java/org/morib/server/domain/category/CategoryReader.java
@@ -1,0 +1,21 @@
+package org.morib.server.domain.category;
+
+import lombok.RequiredArgsConstructor;
+import org.morib.server.domain.category.infra.CategoryRepository;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+@RequiredArgsConstructor
+public class CategoryReader {
+    private final CategoryRepository categoryRepository;
+
+    private Long id;
+    private LocalDate startDate;
+    private LocalDate endDate;
+
+    public void fetchCategories() {
+        // categoryRepository에서 구간에 맞는 category 조회
+    }
+}

--- a/morib/src/main/java/org/morib/server/domain/category/infra/Category.java
+++ b/morib/src/main/java/org/morib/server/domain/category/infra/Category.java
@@ -1,0 +1,11 @@
+package org.morib.server.domain.category.infra;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Category {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_id")
+    private Long id;
+}

--- a/morib/src/main/java/org/morib/server/domain/category/infra/CategoryEntity.java
+++ b/morib/src/main/java/org/morib/server/domain/category/infra/CategoryEntity.java
@@ -1,4 +1,0 @@
-package org.morib.server.domain.category.infra;
-
-public class CategoryEntity {
-}

--- a/morib/src/main/java/org/morib/server/domain/task/TaskReader.java
+++ b/morib/src/main/java/org/morib/server/domain/task/TaskReader.java
@@ -1,0 +1,15 @@
+package org.morib.server.domain.task;
+
+import lombok.RequiredArgsConstructor;
+import org.morib.server.domain.task.infra.TaskRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TaskReader {
+    private final TaskRepository taskRepository;
+
+    public void fetch() {
+        // taskRepository에서 각 category의 task를 조회 + 구간
+    }
+}

--- a/morib/src/main/java/org/morib/server/domain/task/infra/Task.java
+++ b/morib/src/main/java/org/morib/server/domain/task/infra/Task.java
@@ -1,0 +1,12 @@
+package org.morib.server.domain.task.infra;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Task {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "task_id")
+    private Long id;
+
+}

--- a/morib/src/main/java/org/morib/server/domain/task/infra/TaskRepository.java
+++ b/morib/src/main/java/org/morib/server/domain/task/infra/TaskRepository.java
@@ -1,8 +1,8 @@
-package org.morib.server.domain.category.infra;
+package org.morib.server.domain.task.infra;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CategoryRepository extends JpaRepository<Category, Long> {
+public interface TaskRepository extends JpaRepository<Task, Long> {
 }

--- a/morib/src/main/java/org/morib/server/domain/timer/TimerAggregator.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/TimerAggregator.java
@@ -1,0 +1,13 @@
+package org.morib.server.domain.timer;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TimerAggregator {
+
+    public void aggregate() {
+        // 각 task의 timer들을 종합해 오늘 나의 작업시간 계산
+    }
+}

--- a/morib/src/main/java/org/morib/server/domain/timer/TimerReader.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/TimerReader.java
@@ -1,0 +1,15 @@
+package org.morib.server.domain.timer;
+
+import lombok.RequiredArgsConstructor;
+import org.morib.server.domain.timer.infra.TimerRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TimerReader {
+    private final TimerRepository timerRepository;
+
+    public void fetch() {
+        // timerRepository에서 각 task의 timer 조회
+    }
+}

--- a/morib/src/main/java/org/morib/server/domain/timer/infra/Timer.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/infra/Timer.java
@@ -1,0 +1,12 @@
+package org.morib.server.domain.timer.infra;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Timer {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "timer_id")
+    private Long id;
+
+}

--- a/morib/src/main/java/org/morib/server/domain/timer/infra/TimerRepository.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/infra/TimerRepository.java
@@ -1,8 +1,8 @@
-package org.morib.server.domain.category.infra;
+package org.morib.server.domain.timer.infra;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CategoryRepository extends JpaRepository<Category, Long> {
+public interface TimerRepository extends JpaRepository<Timer, Long> {
 }


### PR DESCRIPTION
## 📍 Issue
- closes #3 

## ✨ Key Changes
1. 홈뷰 전체조회, 오늘 나의 작업시간 조회 API 스켈레톤 코드 구현했습니다.
2. service 패키지의 fetch 패키지를 home, timer로 분리했습니다. 그에 따라, Service 인터페이스와 구현체 네이밍을 구체화해두었습니다.

## 💬 To Reviewers
- 지금 제가 작성한 구조는 Facade에서는 Service 인터페이스만을 알고 있고, Service 인터페이스도 실제 로직의 구조 자체를 모르도록 execute() 메소드로 추상화되어있습니다. 그에 따라 ServiceImpl에서 각 엔티티를 가져오는 도메인 클래스인 Reader들을 의존받아 로직을 구성하도록 작성해두었습니다. -> 요 구조가 회의에서 결정된 구조가 맞는지, 올바른 방법인지 잘 모르겠습니다.

코드를 작성하다보니 회의에서 결정된 구조가 맞는 것인지 잘 모르겠어서 일부 구현한 코드를 리뷰 받고 나머지 작업을 진행하려고 합니다 ! :)
