### PR TITLE
Feat [#21] Api 응답 클래스, Auditing 구현

### DIFF
--- a/morib/src/main/java/org/morib/server/domain/allowedSite/infra/AllowedSite.java
+++ b/morib/src/main/java/org/morib/server/domain/allowedSite/infra/AllowedSite.java
@@ -4,10 +4,11 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.morib.server.domain.allowedSite.infra.type.OwnerType;
+import org.morib.server.global.common.BaseTimeEntity;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class AllowedSite {
+public class AllowedSite extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "allowed_site_id")

--- a/morib/src/main/java/org/morib/server/domain/category/infra/Category.java
+++ b/morib/src/main/java/org/morib/server/domain/category/infra/Category.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.morib.server.domain.task.infra.Task;
 import org.morib.server.domain.user.infra.User;
+import org.morib.server.global.common.BaseTimeEntity;
 
 import java.time.LocalDate;
 import java.util.Set;
@@ -13,7 +14,7 @@ import java.util.Set;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Category {
+public class Category extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "category_id")

--- a/morib/src/main/java/org/morib/server/domain/relationship/infra/Relationship.java
+++ b/morib/src/main/java/org/morib/server/domain/relationship/infra/Relationship.java
@@ -5,10 +5,11 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.morib.server.domain.relationship.infra.type.RelationLevel;
 import org.morib.server.domain.user.infra.User;
+import org.morib.server.global.common.BaseTimeEntity;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Relationship {
+public class Relationship extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "permission_id")

--- a/morib/src/main/java/org/morib/server/domain/task/infra/Task.java
+++ b/morib/src/main/java/org/morib/server/domain/task/infra/Task.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import org.morib.server.domain.category.infra.Category;
 import org.morib.server.domain.timer.infra.Timer;
 import org.morib.server.domain.todo.infra.Todo;
+import org.morib.server.global.common.BaseTimeEntity;
 
 import java.time.LocalDate;
 import java.util.Set;
@@ -14,7 +15,7 @@ import java.util.Set;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Task {
+public class Task extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "task_id")

--- a/morib/src/main/java/org/morib/server/domain/timer/infra/Timer.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/infra/Timer.java
@@ -9,11 +9,12 @@ import org.morib.server.domain.task.infra.Task;
 
 import java.time.LocalDate;
 import org.morib.server.domain.user.infra.User;
+import org.morib.server.global.common.BaseTimeEntity;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Timer {
+public class Timer extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "timer_id")

--- a/morib/src/main/java/org/morib/server/domain/todo/infra/Todo.java
+++ b/morib/src/main/java/org/morib/server/domain/todo/infra/Todo.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.morib.server.domain.task.infra.Task;
 import org.morib.server.domain.user.infra.User;
+import org.morib.server.global.common.BaseTimeEntity;
 
 import java.time.LocalDate;
 import java.util.LinkedHashSet;
@@ -14,7 +15,7 @@ import java.util.Set;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Todo {
+public class Todo extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "todo_id")

--- a/morib/src/main/java/org/morib/server/domain/user/infra/User.java
+++ b/morib/src/main/java/org/morib/server/domain/user/infra/User.java
@@ -6,13 +6,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.morib.server.domain.category.infra.Category;
 import org.morib.server.domain.user.infra.type.Platform;
+import org.morib.server.global.common.BaseTimeEntity;
 
 import java.util.Set;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User {
+public class User extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")

--- a/morib/src/main/java/org/morib/server/global/common/ApiResponseUtil.java
+++ b/morib/src/main/java/org/morib/server/global/common/ApiResponseUtil.java
@@ -1,0 +1,23 @@
+package org.morib.server.global.common;
+
+import org.morib.server.global.message.ErrorMessage;
+import org.morib.server.global.message.SuccessMessage;
+import org.springframework.http.ResponseEntity;
+
+public interface ApiResponseUtil {
+    static ResponseEntity<BaseResponse<?>> success(SuccessMessage successMessage) {
+        return ResponseEntity.status(successMessage.getHttpStatus())
+                .body(BaseResponse.of(successMessage));
+    }
+
+    static <T> ResponseEntity<BaseResponse<?>> success(SuccessMessage successMessage, T data) {
+        return ResponseEntity.status(successMessage.getHttpStatus())
+                .body(BaseResponse.of(successMessage, data));
+    }
+
+    static ResponseEntity<BaseResponse<?>> failure(ErrorMessage errorMessage) {
+        return ResponseEntity.status(errorMessage.getHttpStatus())
+                .body(BaseResponse.of(errorMessage));
+    }
+
+}

--- a/morib/src/main/java/org/morib/server/global/common/BaseResponse.java
+++ b/morib/src/main/java/org/morib/server/global/common/BaseResponse.java
@@ -1,0 +1,44 @@
+package org.morib.server.global.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.morib.server.global.message.ErrorMessage;
+import org.morib.server.global.message.SuccessMessage;
+
+
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class BaseResponse<T> {
+    private final int status;
+    private final String code;
+    private final String message;
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    private final T data;
+
+    public static BaseResponse<?> of(SuccessMessage successMessage) {
+        return builder()
+                .status(successMessage.getHttpStatus().value())
+                .message(successMessage.getMessage())
+                .build();
+    }
+
+    public static <T> BaseResponse<?> of(SuccessMessage successMessage, T data) {
+        return builder()
+                .status(successMessage.getHttpStatus().value())
+                .message(successMessage.getMessage())
+                .data(data)
+                .build();
+    }
+
+    public static BaseResponse<?> of(ErrorMessage errorMessage) {
+        return builder()
+                .status(errorMessage.getHttpStatus().value())
+                .message(errorMessage.getMessage())
+                .build();
+    }
+}
+

--- a/morib/src/main/java/org/morib/server/global/common/BaseTimeEntity.java
+++ b/morib/src/main/java/org/morib/server/global/common/BaseTimeEntity.java
@@ -1,0 +1,20 @@
+package org.morib.server.global.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/morib/src/main/java/org/morib/server/global/config/JpaAuditingConfig.java
+++ b/morib/src/main/java/org/morib/server/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package org.morib.server.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/morib/src/main/java/org/morib/server/global/message/ErrorMessage.java
+++ b/morib/src/main/java/org/morib/server/global/message/ErrorMessage.java
@@ -1,0 +1,21 @@
+package org.morib.server.global.message;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public enum ErrorMessage {
+    /**
+     * 400 Bad Request
+     */
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+}

--- a/morib/src/main/java/org/morib/server/global/message/SuccessMessage.java
+++ b/morib/src/main/java/org/morib/server/global/message/SuccessMessage.java
@@ -1,0 +1,19 @@
+package org.morib.server.global.message;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public enum SuccessMessage {
+    /**
+     * 200 Ok
+     */
+    SUCCESS(HttpStatus.OK, "요청이 성공했습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}


### PR DESCRIPTION
## 📍 Issue
- closes #21 

## ✨ Key Changes
- ApiResponseUtil, BaseResponse 추가했습니다.
- ErrorMessage, SuccessMessage에 code는 제외했습니다. 추가로, 200과 400 하나씩만 넣어두었습니다.
- JpaAuditingConfig, BaseTimeEntity 추가했습니다. 
- 엔티티에 Auditing 적용했습니다.

## 💬 To Reviewers
패키지 괜찮은지 ?? 일단 global 패키지 만들고 넣어두었습니다..!
