### PR TITLE
Feat [#57] 구글 소셜 로그인, Spring Security 전면 적용

### DIFF
--- a/morib/build.gradle
+++ b/morib/build.gradle
@@ -27,6 +27,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/morib/src/main/java/org/morib/server/api/homeView/controller/HomeViewController.java
+++ b/morib/src/main/java/org/morib/server/api/homeView/controller/HomeViewController.java
@@ -7,8 +7,11 @@ import org.morib.server.api.homeView.facade.HomeViewFacade;
 import org.morib.server.global.common.ApiResponseUtil;
 import org.morib.server.global.common.BaseResponse;
 import org.morib.server.global.message.SuccessMessage;
+import org.morib.server.global.userauth.CustomUserDetails;
+import org.morib.server.global.userauth.PrincipalHandler;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -18,38 +21,31 @@ import java.time.LocalDate;
 @RequestMapping("/api/v2")
 public class HomeViewController {
     private final HomeViewFacade homeViewFacade;
+    private final PrincipalHandler principalHandler;
 
-    // 홈뷰 전체 조회
     @GetMapping("/home")
-    public ResponseEntity<BaseResponse<?>> fetchHome( // @AuthenticationPrincipal Long userId,
-                                                    @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
-                                                    @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
-        // userId 임시 코드
-        Long userId = 1L;
-        return ApiResponseUtil.success(SuccessMessage.SUCCESS, homeViewFacade.fetchHome(HomeViewRequestDto.of(userId, startDate, endDate)));
+    public ResponseEntity<BaseResponse<?>> fetchHome(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                     @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+                                                     @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+        Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+                homeViewFacade.fetchHome(HomeViewRequestDto.of(userId, startDate, endDate)));
     }
-    
-    // 할일 추가 후 타이머 시작
+
     @PostMapping("/timer/start")
-    public ResponseEntity<BaseResponse<?>> startTimer(//@AuthenticationPrincipal Long userId,
-       @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate,
-        @RequestBody StartTimerRequestDto startTimerRequestDto) {
-        Long mockUserId = 1L;
-        homeViewFacade.startTimer(mockUserId,startTimerRequestDto, targetDate);
+    public ResponseEntity<BaseResponse<?>> startTimer(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate,
+                                                      @RequestBody StartTimerRequestDto startTimerRequestDto) {
+        Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
+        homeViewFacade.startTimer(userId, startTimerRequestDto, targetDate);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 
-    // 오늘 나의 작업시간 조회
     @GetMapping("/timer")
-    public ResponseEntity<BaseResponse<?>> fetchTotalElapsedTimeTodayByUser(//@AuthenticationPrincipal Long userId,
-        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate
-     ){
-        Long mockUserId = 1L;
+    public ResponseEntity<BaseResponse<?>> fetchTotalElapsedTimeTodayByUser(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                                            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate) {
+        Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                homeViewFacade.fetchTotalElapsedTimeTodayByUser(mockUserId, targetDate)
-                );
+                homeViewFacade.fetchTotalElapsedTimeTodayByUser(userId, targetDate));
     }
-
-
-
 }

--- a/morib/src/main/java/org/morib/server/api/homeView/controller/TaskController.java
+++ b/morib/src/main/java/org/morib/server/api/homeView/controller/TaskController.java
@@ -6,7 +6,10 @@ import org.morib.server.api.homeView.facade.HomeViewFacade;
 import org.morib.server.global.common.ApiResponseUtil;
 import org.morib.server.global.common.BaseResponse;
 import org.morib.server.global.message.SuccessMessage;
+import org.morib.server.global.userauth.CustomUserDetails;
+import org.morib.server.global.userauth.PrincipalHandler;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -14,18 +17,17 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v2")
 public class TaskController {
     private final HomeViewFacade homeViewFacade;
+    private final PrincipalHandler principalHandler;
 
-    //태스크 생성
     @PostMapping("/tasks/{categoryId}")
-    public ResponseEntity<BaseResponse<?>> createTask(//@AuthenticationPrincipal Long userId,
-        @PathVariable Long categoryId, @RequestBody
-    CreateTaskRequestDto createTaskRequestDto) {
-        Long mockUserId = 1L;
-        homeViewFacade.createTask(mockUserId, categoryId, createTaskRequestDto);
+    public ResponseEntity<BaseResponse<?>> createTask(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                      @PathVariable Long categoryId,
+                                                      @RequestBody CreateTaskRequestDto createTaskRequestDto) {
+        Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
+        homeViewFacade.createTask(userId, categoryId, createTaskRequestDto);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 
-    // 태스크 상태 변경 (체크박스)
     @PatchMapping("/tasks/{taskId}/status")
     public ResponseEntity<BaseResponse<?>> toggle(@PathVariable Long taskId) {
         homeViewFacade.toggleTaskStatus(taskId);

--- a/morib/src/main/java/org/morib/server/api/modalView/controller/CategoryController.java
+++ b/morib/src/main/java/org/morib/server/api/modalView/controller/CategoryController.java
@@ -5,7 +5,10 @@ import org.morib.server.api.modalView.facade.ModalViewFacade;
 import org.morib.server.global.common.ApiResponseUtil;
 import org.morib.server.global.common.BaseResponse;
 import org.morib.server.global.message.SuccessMessage;
+import org.morib.server.global.userauth.CustomUserDetails;
+import org.morib.server.global.userauth.PrincipalHandler;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -13,11 +16,11 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v2")
 public class CategoryController {
     private final ModalViewFacade modalViewFacade;
+    private final PrincipalHandler principalHandler;
 
     @GetMapping("/categories")
-    public ResponseEntity<BaseResponse<?>> fetchCategoriesByUser(//@AuthenticationPrincipal Long userId
-    ) {
-        Long userId = 1L;
+    public ResponseEntity<BaseResponse<?>> fetchCategoriesByUser(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, modalViewFacade.fetchCategories(userId));
     }
 }

--- a/morib/src/main/java/org/morib/server/api/modalView/controller/ModalViewController.java
+++ b/morib/src/main/java/org/morib/server/api/modalView/controller/ModalViewController.java
@@ -6,42 +6,41 @@ import org.morib.server.api.modalView.facade.ModalViewFacade;
 import org.morib.server.global.common.ApiResponseUtil;
 import org.morib.server.global.common.BaseResponse;
 import org.morib.server.global.message.SuccessMessage;
+import org.morib.server.global.userauth.CustomUserDetails;
+import org.morib.server.global.userauth.PrincipalHandler;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2")
 public class ModalViewController {
-
     private final ModalViewFacade modalViewFacade;
+    private final PrincipalHandler principalHandler;
 
     @PostMapping("/categories")
-    public ResponseEntity<BaseResponse<?>> create(// @AuthenticationPrincipal Long userId,
-                                                @RequestBody CreateCategoryRequestDto createCategoryRequestDto) {
-        Long userId = 1L;
+    public ResponseEntity<BaseResponse<?>> create(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                  @RequestBody CreateCategoryRequestDto createCategoryRequestDto) {
+        Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
         modalViewFacade.createCategory(userId, createCategoryRequestDto);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 
     @GetMapping("/mset/categories/{categoryId}")
-    public ResponseEntity<BaseResponse<?>> fetchAllowedSiteByCategory(// @AuthenticationPrincipal Long userId,
-        @PathVariable Long categoryId){
-        Long mockUserId = 1L;
+    public ResponseEntity<BaseResponse<?>> fetchAllowedSiteByCategory(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                                      @PathVariable Long categoryId) {
+        Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, modalViewFacade.
-            fetchAllowedSiteByCategoryId(mockUserId, categoryId));
+            fetchAllowedSiteByCategoryId(userId, categoryId));
     }
 
     @GetMapping("/mset/tasks/{taskId}")
-    public ResponseEntity<BaseResponse<?>> fetchAllowedSiteByTask(@PathVariable Long taskId){
-        return ApiResponseUtil.success(SuccessMessage.SUCCESS, modalViewFacade.
-            fetchAllowedSiteByTaskId(taskId));
+    public ResponseEntity<BaseResponse<?>> fetchAllowedSiteByTask(@PathVariable Long taskId) {
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+                modalViewFacade.fetchAllowedSiteByTaskId(taskId));
     }
 
-
-
-
-    // 카테고리 삭제
     @DeleteMapping("/categories/{categoryId}")
     public ResponseEntity<BaseResponse<?>> delete(@PathVariable("categoryId") Long categoryId) {
         modalViewFacade.deleteCategoryById(categoryId);
@@ -51,10 +50,5 @@ public class ModalViewController {
     @GetMapping("/tabName")
     public ResponseEntity<BaseResponse<?>> fetchTabNameByUrl(@RequestParam("url") String url) {
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, modalViewFacade.fetchTabNameByUrl(url));
-
     }
-
-
-
-
 }

--- a/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
@@ -16,6 +16,7 @@ import org.morib.server.domain.timer.infra.Timer;
 import org.morib.server.domain.todo.application.FetchTodoService;
 import org.morib.server.domain.todo.infra.Todo;
 import org.morib.server.domain.user.application.FetchUserService;
+import org.morib.server.domain.user.infra.User;
 import org.springframework.transaction.annotation.Transactional;
 
 
@@ -30,9 +31,8 @@ public class TimerViewFacade {
     private final TimerManager timerManager;
 
     @Transactional
-    public void stopAfterSumElapsedTime(Long taskId, StopTimerRequestDto dto) {
-    //  Long mockUserId = 1L;
-    //  User user = fetchUserService.fetchByUserId(mockUserId);   이후에 user 관련해서 여쭤보고 진행!
+    public void stopAfterSumElapsedTime(Long userId, Long taskId, StopTimerRequestDto dto) {
+        User user = fetchUserService.fetchByUserId(userId);
         Task findTask = fetchTaskService.fetchById(taskId);
         Timer timer = fetchTimerService.fetchByTaskAndTargetDate(findTask, dto.targetDate());
         timerManager.addElapsedTime(timer, dto.elapsedTime());
@@ -50,12 +50,10 @@ public class TimerViewFacade {
      * @return
      */
     @Transactional
-    public TodoCardResponseDto fetchTodoCard(Long mockUserId, LocalDate targetDate) {
-        Todo todo = fetchTodoService.fetchByUserIdAndTargetDate(mockUserId, targetDate);
-
+    public TodoCardResponseDto fetchTodoCard(Long userId, LocalDate targetDate) {
+        Todo todo = fetchTodoService.fetchByUserIdAndTargetDate(userId, targetDate);
         LinkedHashSet<Task> tasks = fetchTaskService.fetchByTodoAndSameTargetDate(todo, targetDate);
-        int totalTimeOfToday = fetchTimerService.sumElapsedTimeByUser(fetchUserService.fetchByUserId(mockUserId), targetDate);
-
+        int totalTimeOfToday = fetchTimerService.sumElapsedTimeByUser(fetchUserService.fetchByUserId(userId), targetDate);
         List<TaskInTodoCardDto> taskInTodoCardDtos = tasks.stream()
             .map(t -> getTaskInTodoCardDto(targetDate, t))
             .toList();

--- a/morib/src/main/java/org/morib/server/domain/user/application/FetchUserService.java
+++ b/morib/src/main/java/org/morib/server/domain/user/application/FetchUserService.java
@@ -5,6 +5,4 @@ import org.morib.server.domain.user.infra.User;
 
 public interface FetchUserService {
     User fetchByUserId(Long id);
-
-
 }

--- a/morib/src/main/java/org/morib/server/domain/user/infra/User.java
+++ b/morib/src/main/java/org/morib/server/domain/user/infra/User.java
@@ -1,18 +1,20 @@
 package org.morib.server.domain.user.infra;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.morib.server.domain.category.infra.Category;
 import org.morib.server.domain.user.infra.type.Platform;
+import org.morib.server.domain.user.infra.type.Role;
 import org.morib.server.global.common.BaseTimeEntity;
+import org.morib.server.global.oauth2.userinfo.OAuth2UserInfo;
 
 import java.util.Set;
 
 @Entity
 @Getter
+@Builder(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class User extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,4 +31,27 @@ public class User extends BaseTimeEntity {
     private String refreshToken;
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<Category> categories;
+    @Enumerated(EnumType.STRING)
+    private Role role;
+    private String socialId; // 로그인한 소셜 타입의 식별자 값 (일반 로그인인 경우 null)
+
+    // 유저 권한 설정 메소드
+    public void authorizeUser() {
+        this.role = Role.USER;
+    }
+
+    public void updateRefreshToken(String updateRefreshToken) {
+        this.refreshToken = updateRefreshToken;
+    }
+
+    public static User createByOAuth2UserInfo(Platform platform, OAuth2UserInfo oauth2UserInfo) {
+        return User.builder()
+                .platform(platform)
+                .socialId(oauth2UserInfo.getId())
+                .email(oauth2UserInfo.getEmail())
+                .name(oauth2UserInfo.getName())
+                .imageUrl(oauth2UserInfo.getImageUrl())
+                .role(Role.GUEST)
+                .build();
+    }
 }

--- a/morib/src/main/java/org/morib/server/domain/user/infra/UserRepository.java
+++ b/morib/src/main/java/org/morib/server/domain/user/infra/UserRepository.java
@@ -1,7 +1,12 @@
 package org.morib.server.domain.user.infra;
 
+import org.morib.server.domain.user.infra.type.Platform;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByRefreshToken(String refreshToken);
+    Optional<User> findByPlatformAndSocialId(Platform platform, String socialId);
 
 }

--- a/morib/src/main/java/org/morib/server/domain/user/infra/type/Role.java
+++ b/morib/src/main/java/org/morib/server/domain/user/infra/type/Role.java
@@ -1,0 +1,14 @@
+package org.morib.server.domain.user.infra.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+
+    GUEST("ROLE_GUEST"), USER("ROLE_USER");
+
+    private final String key;
+}
+

--- a/morib/src/main/java/org/morib/server/global/common/BaseResponse.java
+++ b/morib/src/main/java/org/morib/server/global/common/BaseResponse.java
@@ -14,7 +14,6 @@ import org.morib.server.global.message.SuccessMessage;
 @Getter
 public class BaseResponse<T> {
     private final int status;
-    private final String code;
     private final String message;
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     private final T data;

--- a/morib/src/main/java/org/morib/server/global/common/Constants.java
+++ b/morib/src/main/java/org/morib/server/global/common/Constants.java
@@ -1,0 +1,9 @@
+package org.morib.server.global.common;
+
+public abstract class Constants {
+    public static final String AUTHORIZATION = "Authorization";
+    public static final String BEARER = "Bearer ";
+    public static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
+    public static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
+    public static final String ID_CLAIM = "id";
+}

--- a/morib/src/main/java/org/morib/server/global/common/TokenResponseDto.java
+++ b/morib/src/main/java/org/morib/server/global/common/TokenResponseDto.java
@@ -1,0 +1,11 @@
+package org.morib.server.global.common;
+
+public record TokenResponseDto(
+        String accessToken,
+        String refreshToken,
+        Long userId
+) {
+    public static TokenResponseDto of(String accessToken, String refreshToken, Long userId) {
+        return new TokenResponseDto(accessToken, refreshToken, userId);
+    }
+}

--- a/morib/src/main/java/org/morib/server/global/config/SecurityConfig.java
+++ b/morib/src/main/java/org/morib/server/global/config/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
                     oauth2.userInfoEndpoint(user -> user.userService(customOAuth2UserService));
                 });
         http.authorizeHttpRequests((auth) -> auth
-                .requestMatchers("/","/css/**","/images/**","/js/**","/favicon.ico","/h2-console/**").permitAll()
+                .requestMatchers("/","/css/**","/images/**","/js/**","/favicon.ico").permitAll()
                 .anyRequest().authenticated()
         );
         http.addFilterAfter(jwtAuthenticationFilter(), LogoutFilter.class);

--- a/morib/src/main/java/org/morib/server/global/config/SecurityConfig.java
+++ b/morib/src/main/java/org/morib/server/global/config/SecurityConfig.java
@@ -1,0 +1,56 @@
+package org.morib.server.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.morib.server.domain.user.infra.UserRepository;
+import org.morib.server.global.jwt.CustomJwtAuthenticationEntryPoint;
+import org.morib.server.global.jwt.JwtAuthenticationFilter;
+import org.morib.server.global.jwt.JwtService;
+import org.morib.server.global.oauth2.handler.OAuth2LoginFailureHandler;
+import org.morib.server.global.oauth2.handler.OAuth2LoginSuccessHandler;
+import org.morib.server.global.oauth2.service.CustomOAuth2UserService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.RequestCacheConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .requestCache(RequestCacheConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .exceptionHandling(exception -> exception.authenticationEntryPoint(customJwtAuthenticationEntryPoint))
+                .oauth2Login(oauth2 -> {
+                    oauth2.successHandler(oAuth2LoginSuccessHandler);
+                    oauth2.failureHandler(oAuth2LoginFailureHandler);
+                    oauth2.userInfoEndpoint(user -> user.userService(customOAuth2UserService));
+                });
+        http.authorizeHttpRequests((auth) -> auth
+                .requestMatchers("/","/css/**","/images/**","/js/**","/favicon.ico","/h2-console/**").permitAll()
+                .anyRequest().authenticated()
+        );
+        http.addFilterAfter(jwtAuthenticationFilter(), LogoutFilter.class);
+        return http.build();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtService, userRepository);
+        return jwtAuthenticationFilter;
+    }
+}

--- a/morib/src/main/java/org/morib/server/global/config/WebSecurityConfig.java
+++ b/morib/src/main/java/org/morib/server/global/config/WebSecurityConfig.java
@@ -1,0 +1,16 @@
+package org.morib.server.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebSecurityConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("GET", "POST", "DELETE", "PUT", "PATCH", "OPTIONS")
+                .maxAge(3000);
+    }
+}

--- a/morib/src/main/java/org/morib/server/global/jwt/CustomJwtAuthenticationEntryPoint.java
+++ b/morib/src/main/java/org/morib/server/global/jwt/CustomJwtAuthenticationEntryPoint.java
@@ -1,0 +1,34 @@
+package org.morib.server.global.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.morib.server.global.message.ErrorMessage;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomJwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter()
+                .write(objectMapper.writeValueAsString(
+                        ErrorMessage.JWT_UNAUTHORIZED.getMessage()));
+    }
+}

--- a/morib/src/main/java/org/morib/server/global/jwt/JwtAuthenticationFilter.java
+++ b/morib/src/main/java/org/morib/server/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,81 @@
+package org.morib.server.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.morib.server.domain.user.infra.User;
+import org.morib.server.domain.user.infra.UserRepository;
+import org.morib.server.global.userauth.CustomUserAuthentication;
+import org.morib.server.global.userauth.CustomUserDetails;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String NO_CHECK_URL = "/login"; // "/login"으로 들어오는 요청은 Filter 작동 X
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+    private GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        if (request.getRequestURI().equals(NO_CHECK_URL)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        String refreshToken = jwtService.extractRefreshToken(request)
+                .filter(jwtService::isTokenValid)
+                .orElse(null);
+
+        if (refreshToken != null) {
+            checkRefreshTokenAndReIssueAccessToken(response, refreshToken);
+            return;
+        }
+        checkAccessTokenAndAuthentication(request, response, filterChain);
+    }
+
+    public void checkRefreshTokenAndReIssueAccessToken(HttpServletResponse response, String refreshToken) {
+        userRepository.findByRefreshToken(refreshToken)
+                .ifPresent(user -> {
+                    String reIssuedRefreshToken = reIssueRefreshToken(user);
+                    jwtService.sendAccessAndRefreshToken(response, jwtService.createAccessToken(user.getId()),
+                            reIssuedRefreshToken);
+                });
+    }
+
+    private String reIssueRefreshToken(User user) {
+        String reIssuedRefreshToken = jwtService.createRefreshToken();
+        user.updateRefreshToken(reIssuedRefreshToken);
+        userRepository.saveAndFlush(user);
+        return reIssuedRefreshToken;
+    }
+
+    public void checkAccessTokenAndAuthentication(HttpServletRequest request, HttpServletResponse response,
+                                                  FilterChain filterChain) throws ServletException, IOException {
+        log.info("checkAccessTokenAndAuthentication() 호출");
+        jwtService.extractAccessToken(request)
+                .filter(jwtService::isTokenValid)
+                .ifPresent(accessToken ->
+                        jwtService.extractId(accessToken)
+                                .ifPresent(id -> userRepository.findById(Long.valueOf(id))
+                                        .ifPresent(this::saveAuthentication)));
+        filterChain.doFilter(request, response);
+    }
+
+    public void saveAuthentication(User myUser) {
+        CustomUserDetails customUserDetails = CustomUserDetails.of(myUser.getId(), myUser.getEmail(), myUser.getRole().name());
+        CustomUserAuthentication customUserAuthentication =
+                CustomUserAuthentication.of(customUserDetails, null, authoritiesMapper.mapAuthorities(customUserDetails.getAuthorities()));
+        SecurityContextHolder.getContext().setAuthentication(customUserAuthentication);
+    }
+}
+

--- a/morib/src/main/java/org/morib/server/global/jwt/JwtAuthenticationFilter.java
+++ b/morib/src/main/java/org/morib/server/global/jwt/JwtAuthenticationFilter.java
@@ -20,18 +20,12 @@ import java.io.IOException;
 @RequiredArgsConstructor
 @Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-
-    private static final String NO_CHECK_URL = "/login"; // "/login"으로 들어오는 요청은 Filter 작동 X
     private final JwtService jwtService;
     private final UserRepository userRepository;
     private GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        if (request.getRequestURI().equals(NO_CHECK_URL)) {
-            filterChain.doFilter(request, response);
-            return;
-        }
         String refreshToken = jwtService.extractRefreshToken(request)
                 .filter(jwtService::isTokenValid)
                 .orElse(null);

--- a/morib/src/main/java/org/morib/server/global/jwt/JwtService.java
+++ b/morib/src/main/java/org/morib/server/global/jwt/JwtService.java
@@ -106,12 +106,7 @@ public class JwtService {
 
     public Optional<String> extractId(String accessToken) {
         try {
-            Key key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
-            Claims claims = Jwts.parserBuilder()
-                    .setSigningKey(key)
-                    .build()
-                    .parseClaimsJws(accessToken)
-                    .getBody();
+            Claims claims = extractClaimsFromToken(accessToken);
             return Optional.ofNullable(claims.get(ID_CLAIM, String.class));
 
         } catch (Exception e) {
@@ -138,15 +133,19 @@ public class JwtService {
 
     public boolean isTokenValid(String token) {
         try {
-            Jwts.parserBuilder()
-                .setSigningKey(getSigningKey())
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
+            extractClaimsFromToken(token);
             return true;
         } catch (Exception e) {
             throw new UnauthorizedException(ErrorMessage.INVALID_TOKEN);
         }
+    }
+
+    private Claims extractClaimsFromToken(String token) {
+        return Jwts.parserBuilder()
+            .setSigningKey(getSigningKey())
+            .build()
+            .parseClaimsJws(token)
+            .getBody();
     }
 
     private SecretKey getSigningKey() {

--- a/morib/src/main/java/org/morib/server/global/jwt/JwtService.java
+++ b/morib/src/main/java/org/morib/server/global/jwt/JwtService.java
@@ -1,0 +1,157 @@
+package org.morib.server.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.morib.server.domain.user.infra.UserRepository;
+import org.morib.server.global.exception.NotFoundException;
+import org.morib.server.global.exception.UnauthorizedException;
+import org.morib.server.global.message.ErrorMessage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Optional;
+
+import static org.morib.server.global.common.Constants.*;
+
+@Service
+@RequiredArgsConstructor
+@Getter
+@Slf4j
+public class JwtService {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+    @Value("${jwt.expiration.access-token}")
+    private Long accessTokenExpirationPeriod;
+    @Value("${jwt.expiration.refresh-token}")
+    private Long refreshTokenExpirationPeriod;
+    @Value("${jwt.header.access-token}")
+    private String accessHeader;
+    @Value("${jwt.header.refresh-token}")
+    private String refreshHeader;
+
+    private final UserRepository userRepository;
+
+    public String createAccessToken(Long id) {
+        final Claims claims = getClaimsWithId(id, accessTokenExpirationPeriod);
+        return generateJwt(claims, ACCESS_TOKEN_SUBJECT);
+   }
+
+    public String createRefreshToken() {
+        final Claims claims = getClaims(refreshTokenExpirationPeriod);
+        return generateJwt(claims, REFRESH_TOKEN_SUBJECT);
+    }
+
+    private String generateJwt(Claims claims, String subject) {
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE) // Header
+                .setSubject(subject)
+                .setClaims(claims) // Claim
+                .signWith(getSigningKey()) // Signature
+                .compact();
+    }
+
+    private Claims getClaims(final Long tokenExpirationPeriod) {
+        final Date now = new Date();
+        return Jwts.claims()
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + tokenExpirationPeriod));
+    }
+
+    private Claims getClaimsWithId(final Long id, final Long tokenExpirationPeriod) {
+        final Date now = new Date();
+        Claims claims = Jwts.claims()
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + tokenExpirationPeriod));
+        claims.put(ID_CLAIM, id);
+        return claims;
+    }
+
+    public void sendAccessToken(HttpServletResponse response, String accessToken) {
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setHeader(accessHeader, accessToken);
+        log.info("재발급된 Access Token : {}", accessToken);
+    }
+
+    public void sendAccessAndRefreshToken(HttpServletResponse response, String accessToken, String refreshToken) {
+        response.setStatus(HttpServletResponse.SC_OK);
+        setAccessTokenHeader(response, accessToken);
+        setRefreshTokenHeader(response, refreshToken);
+        log.info("Access Token, Refresh Token 헤더 설정 완료");
+    }
+
+    public Optional<String> extractRefreshToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(AUTHORIZATION))
+                .filter(refreshToken -> refreshToken.startsWith(BEARER))
+                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+    }
+
+    public Optional<String> extractAccessToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(AUTHORIZATION))
+                .filter(accessToken -> accessToken.startsWith(BEARER))
+                .map(accessToken -> accessToken.replace(BEARER, ""));
+    }
+
+    public Optional<String> extractId(String accessToken) {
+        try {
+            Key key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+            return Optional.ofNullable(claims.get(ID_CLAIM, String.class));
+
+        } catch (Exception e) {
+            log.error("액세스 토큰이 유효하지 않습니다.");
+            return Optional.empty();
+        }
+    }
+
+    public void setAccessTokenHeader(HttpServletResponse response, String accessToken) {
+        response.setHeader(accessHeader, accessToken);
+    }
+
+    public void setRefreshTokenHeader(HttpServletResponse response, String refreshToken) {
+        response.setHeader(refreshHeader, refreshToken);
+    }
+
+    public void updateRefreshToken(Long userId, String refreshToken) {
+        userRepository.findById(userId)
+                .ifPresentOrElse(
+                        user -> user.updateRefreshToken(refreshToken),
+                        () -> new NotFoundException(ErrorMessage.NOT_FOUND)
+                );
+    }
+
+    public boolean isTokenValid(String token) {
+        try {
+            Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+            return true;
+        } catch (Exception e) {
+            throw new UnauthorizedException(ErrorMessage.INVALID_TOKEN);
+        }
+    }
+
+    private SecretKey getSigningKey() {
+        String encodedKey = Base64.getEncoder().encodeToString(secretKey.getBytes()); //SecretKey 통해 서명 생성
+        return Keys.hmacShaKeyFor(encodedKey.getBytes());   //일반적으로 HMAC (Hash-based Message Authentication Code) 알고리즘 사용
+    }
+}
+

--- a/morib/src/main/java/org/morib/server/global/message/ErrorMessage.java
+++ b/morib/src/main/java/org/morib/server/global/message/ErrorMessage.java
@@ -19,6 +19,8 @@ public enum ErrorMessage {
      * 401 Unauthorized
      */
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+    JWT_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "사용자의 로그인 검증을 실패했습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효한 토큰이 아닙니다"),
 
     /**
      * 403 Forbidden

--- a/morib/src/main/java/org/morib/server/global/oauth2/CustomOAuth2User.java
+++ b/morib/src/main/java/org/morib/server/global/oauth2/CustomOAuth2User.java
@@ -1,0 +1,24 @@
+package org.morib.server.global.oauth2;
+
+import lombok.Getter;
+import org.morib.server.domain.user.infra.type.Role;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+@Getter
+public class CustomOAuth2User extends DefaultOAuth2User {
+
+    private Role role;
+    private Long userId;
+
+    public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities,
+                            Map<String, Object> attributes, String nameAttributeKey,
+                            Role role, Long userId) {
+        super(authorities, attributes, nameAttributeKey);
+        this.role = role;
+        this.userId = userId;
+    }
+}

--- a/morib/src/main/java/org/morib/server/global/oauth2/OAuthAttributes.java
+++ b/morib/src/main/java/org/morib/server/global/oauth2/OAuthAttributes.java
@@ -1,0 +1,36 @@
+package org.morib.server.global.oauth2;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.morib.server.domain.user.infra.type.Platform;
+import org.morib.server.global.oauth2.userinfo.GoogleOAuth2UserInfo;
+import org.morib.server.global.oauth2.userinfo.OAuth2UserInfo;
+
+
+import java.util.Map;
+
+@Getter
+public class OAuthAttributes {
+
+    private String nameAttributeKey;
+    private OAuth2UserInfo oauth2UserInfo;
+
+    @Builder
+    public OAuthAttributes(String nameAttributeKey, OAuth2UserInfo oauth2UserInfo) {
+        this.nameAttributeKey = nameAttributeKey;
+        this.oauth2UserInfo = oauth2UserInfo;
+    }
+
+    public static OAuthAttributes of(Platform platform,
+                                     String userNameAttributeName, Map<String, Object> attributes) {
+        return ofGoogle(userNameAttributeName, attributes);
+    }
+
+    public static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oauth2UserInfo(new GoogleOAuth2UserInfo(attributes))
+                .build();
+    }
+
+}

--- a/morib/src/main/java/org/morib/server/global/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/morib/src/main/java/org/morib/server/global/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -1,0 +1,22 @@
+package org.morib.server.global.oauth2.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.getWriter().write("소셜 로그인 실패! 서버 로그를 확인해주세요.");
+        log.info("소셜 로그인에 실패했습니다. 에러 메시지 : {}", exception.getMessage());
+    }
+}

--- a/morib/src/main/java/org/morib/server/global/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/morib/src/main/java/org/morib/server/global/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,65 @@
+package org.morib.server.global.oauth2.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.morib.server.domain.user.infra.User;
+import org.morib.server.domain.user.infra.UserRepository;
+import org.morib.server.domain.user.infra.type.Role;
+import org.morib.server.global.common.ApiResponseUtil;
+import org.morib.server.global.common.TokenResponseDto;
+import org.morib.server.global.jwt.JwtService;
+import org.morib.server.global.message.SuccessMessage;
+import org.morib.server.global.oauth2.CustomOAuth2User;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    @Transactional
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        log.info("OAuth2 Login 성공!");
+        try {
+            CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+            if(oAuth2User.getRole() == Role.GUEST) {
+                String accessToken = jwtService.createAccessToken(oAuth2User.getUserId());
+                response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
+                jwtService.sendAccessAndRefreshToken(response, accessToken, null);
+                User findUser = userRepository.findById(oAuth2User.getUserId())
+                        .orElseThrow(() -> new IllegalArgumentException("이메일에 해당하는 유저가 없습니다."));
+                findUser.authorizeUser();
+            } else {
+                loginSuccess(response, oAuth2User); // 로그인에 성공한 경우 access, refresh 토큰 생성
+            }
+        } catch (Exception e) {
+            throw e;
+        }
+
+    }
+
+    // TODO : 소셜 로그인 시에도 무조건 토큰 생성하지 말고 JWT 인증 필터처럼 RefreshToken 유/무에 따라 다르게 처리해보기
+    private void loginSuccess(HttpServletResponse response, CustomOAuth2User oAuth2User) throws IOException {
+        String accessToken = jwtService.createAccessToken(oAuth2User.getUserId());
+        String refreshToken = jwtService.createRefreshToken();
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.getWriter().write(objectMapper.writeValueAsString(ApiResponseUtil.success(SuccessMessage.SUCCESS, TokenResponseDto.of(accessToken, refreshToken, oAuth2User.getUserId())).getBody()));
+    }
+
+}

--- a/morib/src/main/java/org/morib/server/global/oauth2/service/CustomOAuth2UserService.java
+++ b/morib/src/main/java/org/morib/server/global/oauth2/service/CustomOAuth2UserService.java
@@ -25,6 +25,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
     private final UserRepository userRepository;
 
+    // TODO : 메서드 분리 리팩토링 필요
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         log.info("CustomOAuth2UserService.loadUser() 실행 - OAuth2 로그인 요청 진입");

--- a/morib/src/main/java/org/morib/server/global/oauth2/service/CustomOAuth2UserService.java
+++ b/morib/src/main/java/org/morib/server/global/oauth2/service/CustomOAuth2UserService.java
@@ -1,0 +1,67 @@
+package org.morib.server.global.oauth2.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.morib.server.domain.user.infra.User;
+import org.morib.server.domain.user.infra.UserRepository;
+import org.morib.server.domain.user.infra.type.Platform;
+import org.morib.server.global.oauth2.CustomOAuth2User;
+import org.morib.server.global.oauth2.OAuthAttributes;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        log.info("CustomOAuth2UserService.loadUser() 실행 - OAuth2 로그인 요청 진입");
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        Platform platform = getSocialType(registrationId);
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        OAuthAttributes extractAttributes = OAuthAttributes.of(platform, userNameAttributeName, attributes);
+        User createdUser = getUser(extractAttributes, platform);
+        return new CustomOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(createdUser.getRole().getKey())),
+                attributes,
+                extractAttributes.getNameAttributeKey(),
+                createdUser.getRole(),
+                createdUser.getId()
+        );
+    }
+
+    private Platform getSocialType(String registrationId) {
+        return Platform.GOOGLE;
+    }
+
+    private User getUser(OAuthAttributes attributes, Platform platform) {
+        User findUser = userRepository.findByPlatformAndSocialId(platform,
+                attributes.getOauth2UserInfo().getId()).orElse(null);
+
+        if(findUser == null) {
+            return saveUser(attributes, platform);
+        }
+        return findUser;
+    }
+
+    private User saveUser(OAuthAttributes attributes, Platform platform) {
+        User createdUser = User.createByOAuth2UserInfo(platform, attributes.getOauth2UserInfo());
+        return userRepository.saveAndFlush(createdUser);
+    }
+}

--- a/morib/src/main/java/org/morib/server/global/oauth2/userinfo/GoogleOAuth2UserInfo.java
+++ b/morib/src/main/java/org/morib/server/global/oauth2/userinfo/GoogleOAuth2UserInfo.java
@@ -1,0 +1,30 @@
+package org.morib.server.global.oauth2.userinfo;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
+
+    public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getImageUrl() {
+        return (String) attributes.get("picture");
+    }
+}

--- a/morib/src/main/java/org/morib/server/global/oauth2/userinfo/OAuth2UserInfo.java
+++ b/morib/src/main/java/org/morib/server/global/oauth2/userinfo/OAuth2UserInfo.java
@@ -1,0 +1,20 @@
+package org.morib.server.global.oauth2.userinfo;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+
+    protected Map<String, Object> attributes;
+
+    public OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public abstract String getId();
+
+    public abstract String getName();
+
+    public abstract String getEmail();
+
+    public abstract String getImageUrl();
+}

--- a/morib/src/main/java/org/morib/server/global/userauth/CustomUserAuthentication.java
+++ b/morib/src/main/java/org/morib/server/global/userauth/CustomUserAuthentication.java
@@ -1,0 +1,17 @@
+package org.morib.server.global.userauth;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class CustomUserAuthentication extends UsernamePasswordAuthenticationToken {
+
+    public CustomUserAuthentication(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+        super(principal, credentials, authorities);
+    }
+
+    public static CustomUserAuthentication of(CustomUserDetails customUserDetails, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+        return new CustomUserAuthentication(customUserDetails, credentials, authorities);
+    }
+}

--- a/morib/src/main/java/org/morib/server/global/userauth/CustomUserDetails.java
+++ b/morib/src/main/java/org/morib/server/global/userauth/CustomUserDetails.java
@@ -1,0 +1,54 @@
+package org.morib.server.global.userauth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+@Getter
+@AllArgsConstructor
+public class CustomUserDetails implements UserDetails {
+    private Long userId;
+    private String email;
+    private String roles;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+
+    public static CustomUserDetails of (Long userId, String email, String roles) {
+        return new CustomUserDetails(userId, email, roles);
+    }
+}

--- a/morib/src/main/java/org/morib/server/global/userauth/PrincipalHandler.java
+++ b/morib/src/main/java/org/morib/server/global/userauth/PrincipalHandler.java
@@ -1,0 +1,22 @@
+package org.morib.server.global.userauth;
+
+import org.morib.server.global.exception.UnauthorizedException;
+import org.morib.server.global.message.ErrorMessage;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PrincipalHandler {
+
+    public Long getUserIdFromUserDetails(CustomUserDetails customUserDetails) {
+        isUserDetailsNull(customUserDetails);
+        return customUserDetails.getUserId();
+    }
+
+    public void isUserDetailsNull(
+            final CustomUserDetails customUserDetails
+    ) {
+        if (customUserDetails == null) {
+            throw new UnauthorizedException(ErrorMessage.JWT_UNAUTHORIZED);
+        }
+    }
+}


### PR DESCRIPTION
## 📍 Issue
- closes #57 

## ✨ Key Changes
- JwtService 메서드 분리해서 가독성 높였습니다.
- @Value로 yaml 참조하게 변경했습니다.
- 기존 Jwt 빌딩 방식을 jjwt로 변경했습니다. (Jwts.~) 
- Attributes 클래스에서 toEntity 하는 코드를 User의 정적 팩토리 메소드로 변경했습니다.
- 에러 처리는 다 커스텀으로 변경이 안 된 것 같습니다 ,, 조금씩 보입니다 ,, 죄송 ,,
- 불필요한 공백, 주석 전부 제거했습니다.
- AuthenticationPrincipal 전면 적용했습니다. PrincipalHandler에 CustomUserDetails 객체를 userId로 뽑아오는 코드 넣어줬습니다.
- indentation, depth 보이는 건 깔끔하게 정리했습니다.

## 💬 To Reviewers
커밋을 최대한 작업별로 나눠보려고 했는데도 많이 크네요 ,, ㅠㅋㅋ
패키지를 진짜 어떻게 해야할지 고민입니다. 한번 같이 논의해보시죠 ..
