### PR TITLE
Refactor [#62] 카테고리 start, endDate 삭제로 인한 로직 수정

### DIFF
--- a/morib/src/main/java/org/morib/server/api/homeView/dto/fetch/HomeViewResponseDto.java
+++ b/morib/src/main/java/org/morib/server/api/homeView/dto/fetch/HomeViewResponseDto.java
@@ -1,5 +1,6 @@
 package org.morib.server.api.homeView.dto.fetch;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.morib.server.api.homeView.vo.CombinedCategoryAndTaskInfo;
 
 import java.time.LocalDate;
@@ -7,6 +8,7 @@ import java.util.List;
 
 public record HomeViewResponseDto (
         LocalDate date,
+        @JsonProperty("categories")
         List<CombinedCategoryAndTaskInfo> combinedCategoryAndTaskInfos
 ) {
     public static HomeViewResponseDto of(LocalDate date, List<CombinedCategoryAndTaskInfo> combinedCategoryAndTaskInfos) {

--- a/morib/src/main/java/org/morib/server/api/homeView/vo/CategoryInfo.java
+++ b/morib/src/main/java/org/morib/server/api/homeView/vo/CategoryInfo.java
@@ -6,16 +6,12 @@ import java.time.LocalDate;
 
 public record CategoryInfo(
         Long id,
-        String name,
-        LocalDate startDate,
-        LocalDate endDate
+        String name
 ) {
     public static CategoryInfo of(Category category) {
         return new CategoryInfo(
                 category.getId(),
-                category.getName(),
-                category.getStartDate(),
-                category.getEndDate());
+                category.getName());
     }
 }
 

--- a/morib/src/main/java/org/morib/server/api/homeView/vo/TaskInfo.java
+++ b/morib/src/main/java/org/morib/server/api/homeView/vo/TaskInfo.java
@@ -9,7 +9,7 @@ public record TaskInfo(
         String name,
         LocalDate startDate,
         LocalDate endDate,
-        int targetTime,
+        int elapsedTime,
         boolean isComplete
 ) {
     public static TaskInfo of(Task task, int elapsedTime) {

--- a/morib/src/main/java/org/morib/server/api/modalView/dto/CreateCategoryRequestDto.java
+++ b/morib/src/main/java/org/morib/server/api/modalView/dto/CreateCategoryRequestDto.java
@@ -1,5 +1,6 @@
 package org.morib.server.api.modalView.dto;
 
+import org.morib.server.api.modalView.vo.AllowedSiteInfo;
 import org.morib.server.domain.allowedSite.infra.AllowedSite;
 
 import java.time.LocalDate;
@@ -7,9 +8,6 @@ import java.util.List;
 
 public record CreateCategoryRequestDto(
         String name,
-        LocalDate startDate,
-        LocalDate endDate,
-        List<AllowedSite> allowedSites
+        List<AllowedSiteInfo> msets
 ) {
-
 }

--- a/morib/src/main/java/org/morib/server/api/modalView/facade/ModalViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/modalView/facade/ModalViewFacade.java
@@ -43,11 +43,15 @@ public class ModalViewFacade {
     @Transactional
     public void createCategory(Long userId, CreateCategoryRequestDto createCategoryRequestDto) {
         User user = fetchUserService.fetchByUserId(userId);
-        Category createdCategory = createCategoryService.create(createCategoryRequestDto.name(),
-            createCategoryRequestDto.startDate(), createCategoryRequestDto.endDate(), user);
-        createCategoryRequestDto.allowedSites().stream().map(
-            allowedSite -> createAllowedSiteService.create(allowedSite.getSiteName(),
-                allowedSite.getSiteUrl(), OwnerType.CATEGORY, createdCategory.getId()));
+        Category createdCategory = createCategoryService.create(createCategoryRequestDto.name(), user);
+        createCategoryRequestDto.msets().stream().forEach(
+                allowedSite -> createAllowedSiteService.create(
+                        allowedSite.name(),
+                        allowedSite.url(),
+                        OwnerType.CATEGORY,
+                        createdCategory.getId()
+                )
+        );
     }
 
     @Transactional(readOnly = true)
@@ -84,9 +88,11 @@ public class ModalViewFacade {
             map(AllowSiteForCalledByTask::of)
             .toList();
     }
+
     public void deleteCategoryById(Long categoryId){
             deleteCategoryService.deleteById(categoryId);
-        }
+    }
+
     public List<CategoryInfo> fetchCategories(Long userId) {
         User user = fetchUserService.fetchByUserId(userId);
         return fetchCategoryService.fetchByUser(user).stream()

--- a/morib/src/main/java/org/morib/server/api/modalView/facade/ModalViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/modalView/facade/ModalViewFacade.java
@@ -6,10 +6,7 @@ import org.morib.server.annotation.Facade;
 import org.morib.server.api.modalView.dto.AllowedSiteByCategoryResponseDto;
 import org.morib.server.api.modalView.dto.AllowedSiteByTaskResponseDto;
 import org.morib.server.api.modalView.dto.CreateCategoryRequestDto;
-import org.morib.server.api.modalView.vo.AllowSiteForCalledByTask;
-import org.morib.server.api.modalView.vo.CategoryInfoInAllowedSite;
-import org.morib.server.api.modalView.vo.AllowSiteForCalledByCatgory;
-import org.morib.server.api.modalView.vo.TaskInfoInAllowedSite;
+import org.morib.server.api.modalView.vo.*;
 import org.morib.server.domain.allowedSite.application.CreateAllowedSiteService;
 import org.morib.server.domain.allowedSite.application.FetchAllowedSiteService;
 import org.morib.server.domain.allowedSite.application.FetchTabNameService;
@@ -44,12 +41,16 @@ public class ModalViewFacade {
     public void createCategory(Long userId, CreateCategoryRequestDto createCategoryRequestDto) {
         User user = fetchUserService.fetchByUserId(userId);
         Category createdCategory = createCategoryService.create(createCategoryRequestDto.name(), user);
-        createCategoryRequestDto.msets().stream().forEach(
+        createAllowedSites(createdCategory.getId(), createCategoryRequestDto.msets());
+    }
+
+    private void createAllowedSites(Long id, List<AllowedSiteInfo> allowedSiteInfos) {
+        allowedSiteInfos.stream().forEach(
                 allowedSite -> createAllowedSiteService.create(
                         allowedSite.name(),
                         allowedSite.url(),
                         OwnerType.CATEGORY,
-                        createdCategory.getId()
+                        id
                 )
         );
     }

--- a/morib/src/main/java/org/morib/server/api/modalView/vo/AllowedSiteInfo.java
+++ b/morib/src/main/java/org/morib/server/api/modalView/vo/AllowedSiteInfo.java
@@ -1,0 +1,7 @@
+package org.morib.server.api.modalView.vo;
+
+public record AllowedSiteInfo(
+        String name,
+        String url
+) {
+}

--- a/morib/src/main/java/org/morib/server/domain/category/application/CreateCategoryService.java
+++ b/morib/src/main/java/org/morib/server/domain/category/application/CreateCategoryService.java
@@ -6,5 +6,5 @@ import org.morib.server.domain.user.infra.User;
 import java.time.LocalDate;
 
 public interface CreateCategoryService {
-    Category create(String name, LocalDate startDate, LocalDate endDate, User user);
+    Category create(String name, User user);
 }

--- a/morib/src/main/java/org/morib/server/domain/category/application/CreateCategoryServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/category/application/CreateCategoryServiceImpl.java
@@ -14,8 +14,8 @@ public class CreateCategoryServiceImpl implements CreateCategoryService{
     private final CategoryRepository categoryRepository;
 
     @Override
-    public Category create(String name, LocalDate startDate, LocalDate endDate, User user) {
-        return categoryRepository.save(Category.create(name, startDate, endDate, user));
+    public Category create(String name, User user) {
+        return categoryRepository.save(Category.create(name, user));
     }
 
 }

--- a/morib/src/main/java/org/morib/server/domain/category/infra/Category.java
+++ b/morib/src/main/java/org/morib/server/domain/category/infra/Category.java
@@ -23,7 +23,6 @@ public class Category extends BaseTimeEntity {
     private Long id;
     @Column(nullable = false)
     private String name;
-    @Column(nullable = false)
     private LocalDate startDate;
     private LocalDate endDate;
     @ManyToOne

--- a/morib/src/main/java/org/morib/server/domain/category/infra/Category.java
+++ b/morib/src/main/java/org/morib/server/domain/category/infra/Category.java
@@ -31,11 +31,9 @@ public class Category extends BaseTimeEntity {
     @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<Task> tasks = new LinkedHashSet<>();
 
-    public static Category create(String name, LocalDate startDate, LocalDate endDate, User user) {
+    public static Category create(String name, User user) {
         return Category.builder()
                 .name(name)
-                .startDate(startDate)
-                .endDate(endDate)
                 .user(user)
                 .build();
     }


### PR DESCRIPTION
## 📍 Issue
- closes #62 

## ✨ Key Changes
카테고리 startDate, endDate 로직에서 제외했습니다.

엔티티에서는 startDate nullable로 풀어준 후, null로 들어가도록 create 정적 팩토리 메서드에서 파라미터 제외했습니다.

TaskInfo targetTime -> `elapsedTime` 으로 수정했습니다.

allowedSiteInfo 생성했습니다. allowedSite의 모든 필드가 아닌 name, url만 받기도 하고, request로 들어올 때 siteName, siteUrl이 아닌 원래의 api 명세 대로 들어올 수 있게 새로 dto 생성해서 처리했습니다.

## 💬 To Reviewers
HomeViewFacade 로직 변경이 큰데, 하다보니 헷갈려서 주석처리로 설명 써뒀습니다. 추후 기획 요구사항 픽스되면 제거하겠습니다.

<img width="284" alt="스크린샷 2024-09-26 23 44 21" src="https://github.com/user-attachments/assets/6d9f2117-4138-4dfc-b114-d46d41de187b">

AllowedSite라고 된 것도 있고 AllowSite라고 된 것도 있더라구요! 네이밍 정리를 하면 좋을 듯 싶습니다.

PR이 좀 크네요 ,, 천천히 보시고 리뷰해주시면 감사하겠습니다 :) !!
