### PR TITLE
Feat [#77] 카테고리 이름 수정 api 구현

### DIFF
--- a/morib/src/main/java/org/morib/server/api/modalView/controller/CategoryController.java
+++ b/morib/src/main/java/org/morib/server/api/modalView/controller/CategoryController.java
@@ -1,6 +1,7 @@
 package org.morib.server.api.modalView.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.morib.server.api.modalView.dto.UpdateCategoryNameRequestDto;
 import org.morib.server.api.modalView.facade.ModalViewFacade;
 import org.morib.server.global.common.ApiResponseUtil;
 import org.morib.server.global.common.BaseResponse;
@@ -23,4 +24,14 @@ public class CategoryController {
         Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, modalViewFacade.fetchCategories(userId));
     }
+
+    @PatchMapping("/categories/{categoryId}")
+    public ResponseEntity<BaseResponse<?>> updateCategoryName(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                              @PathVariable("categoryId") Long categoryId,
+                                                              @RequestBody UpdateCategoryNameRequestDto updateCategoryNameRequestDto) {
+        Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
+        modalViewFacade.updateCategoryNameById(userId, categoryId, updateCategoryNameRequestDto);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS);
+    }
+
 }

--- a/morib/src/main/java/org/morib/server/api/modalView/dto/UpdateCategoryNameRequestDto.java
+++ b/morib/src/main/java/org/morib/server/api/modalView/dto/UpdateCategoryNameRequestDto.java
@@ -1,0 +1,6 @@
+package org.morib.server.api.modalView.dto;
+
+public record UpdateCategoryNameRequestDto(
+        String name
+) {
+}

--- a/morib/src/main/java/org/morib/server/api/modalView/facade/ModalViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/modalView/facade/ModalViewFacade.java
@@ -4,9 +4,12 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.morib.server.annotation.Facade;
 import org.morib.server.api.modalView.dto.CreateCategoryRequestDto;
+import org.morib.server.api.modalView.dto.UpdateCategoryNameRequestDto;
 import org.morib.server.domain.allowedSite.application.FetchTabNameService;
+import org.morib.server.domain.category.CategoryManager;
 import org.morib.server.domain.category.application.CreateCategoryService;
 import org.morib.server.domain.category.application.FetchCategoryService;
+import org.morib.server.domain.category.infra.Category;
 import org.morib.server.domain.user.application.FetchUserService;
 import org.morib.server.domain.user.infra.User;
 import org.morib.server.api.homeView.vo.CategoryInfo;
@@ -23,6 +26,7 @@ public class ModalViewFacade {
     private final DeleteCategoryService deleteCategoryService;
     private final CreateCategoryService createCategoryService;
     private final FetchTabNameService fetchTabNameService;
+    private final CategoryManager categoryManager;
 
     @Transactional
     public void createCategory(Long userId, CreateCategoryRequestDto createCategoryRequestDto) {
@@ -43,5 +47,12 @@ public class ModalViewFacade {
 
     public TabNameByUrlResponse fetchTabNameByUrl(String url) {
         return TabNameByUrlResponse.of(fetchTabNameService.fetch(url));
+    }
+
+    @Transactional
+    public void updateCategoryNameById(Long userId, Long categoryId, UpdateCategoryNameRequestDto updateCategoryNameRequestDto) {
+        User findUser = fetchUserService.fetchByUserId(userId);
+        Category findCategory = fetchCategoryService.fetchByUserAndCategoryId(findUser, categoryId);
+        categoryManager.updateName(findCategory, updateCategoryNameRequestDto.name());
     }
 }

--- a/morib/src/main/java/org/morib/server/api/modalView/facade/ModalViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/modalView/facade/ModalViewFacade.java
@@ -34,6 +34,7 @@ public class ModalViewFacade {
         createCategoryService.create(createCategoryRequestDto.name(), user);
     }
 
+    @Transactional
     public void deleteCategoryById(Long categoryId){
             deleteCategoryService.deleteById(categoryId);
     }

--- a/morib/src/main/java/org/morib/server/domain/category/CategoryManager.java
+++ b/morib/src/main/java/org/morib/server/domain/category/CategoryManager.java
@@ -1,8 +1,12 @@
 package org.morib.server.domain.category;
 
 import org.morib.server.annotation.Manager;
+import org.morib.server.domain.category.infra.Category;
 
 @Manager
 public class CategoryManager {
 
+    public void updateName(Category category, String name) {
+        category.updateName(name);
+    }
 }

--- a/morib/src/main/java/org/morib/server/domain/category/application/FetchCategoryService.java
+++ b/morib/src/main/java/org/morib/server/domain/category/application/FetchCategoryService.java
@@ -15,6 +15,5 @@ public interface FetchCategoryService {
     List<Category> fetchByUserIdInRange(Long userId, LocalDate startDate, LocalDate endDate);
     Set<Category> fetchByUser(User user);
     CategoryWithTasks convertToCategoryWithTasks(Category category, LinkedHashSet<TaskWithTimers> taskWithTimers);
-
     Category fetchByUserAndCategoryId(User findUser, Long categoryId);
 }

--- a/morib/src/main/java/org/morib/server/domain/category/infra/Category.java
+++ b/morib/src/main/java/org/morib/server/domain/category/infra/Category.java
@@ -38,4 +38,8 @@ public class Category extends BaseTimeEntity {
                 .build();
     }
 
+    public void updateName(String name) {
+        this.name = name;
+    }
+
 }


### PR DESCRIPTION
## 📍 Issue
- closes #77 

## ✨ Key Changes
카테고리 이름 수정 api 구현했습니다.

카테고리 삭제 api에 `@Transactional` 누락되어있어서 추가했습니다.

## 💬 To Reviewers
현재 더티체킹으로 엔티티의 상태를 변경하는 건 Manager, 
단순 조회나 로직은 Service 인터페이스와 구현체로 사용하고 있는데요 !

점점 갈수록 Manager와 Service의 경계가 모호해질 수도 있겠다는 생각이 드는데, 어떻게 생각하시는지 궁금합니다!
