### PR TITLE
Feat [#102] 로그아웃, 회원탈퇴, 토큰 재발급 api 구현

### DIFF
--- a/morib/.gitignore
+++ b/morib/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ## yaml
 *.yaml
+
+## secret properties
+**/src/main/java/org/morib/server/global/common/SecretProperties.java

--- a/morib/src/main/java/org/morib/server/MoribApplication.java
+++ b/morib/src/main/java/org/morib/server/MoribApplication.java
@@ -1,9 +1,12 @@
 package org.morib.server;
 
+import org.morib.server.global.common.SecretProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties(SecretProperties.class)
 public class MoribApplication {
 
     public static void main(String[] args) {

--- a/morib/src/main/java/org/morib/server/api/loginView/controller/UserAuthController.java
+++ b/morib/src/main/java/org/morib/server/api/loginView/controller/UserAuthController.java
@@ -1,0 +1,41 @@
+package org.morib.server.api.loginView.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.morib.server.api.loginView.facade.UserAuthFacade;
+import org.morib.server.global.common.ApiResponseUtil;
+import org.morib.server.global.common.BaseResponse;
+import org.morib.server.global.exception.UnauthorizedException;
+import org.morib.server.global.message.ErrorMessage;
+import org.morib.server.global.message.SuccessMessage;
+import org.morib.server.global.userauth.CustomUserDetails;
+import org.morib.server.global.userauth.PrincipalHandler;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestTemplate;
+
+import static org.morib.server.global.common.Constants.AUTHORIZATION;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2")
+public class UserAuthController {
+
+    private final PrincipalHandler principalHandler;
+    private final UserAuthFacade userAuthFacade;
+
+    @PostMapping("/users/reissue")
+    public ResponseEntity<BaseResponse<?>> reissue(@RequestHeader(AUTHORIZATION) final String refreshToken) {
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS, userAuthFacade.reissue(refreshToken));
+    }
+
+    @DeleteMapping("/users/withdraw")
+    public ResponseEntity<BaseResponse<?>> withdraw(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
+        userAuthFacade.withdraw(userId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS);
+    }
+}

--- a/morib/src/main/java/org/morib/server/api/loginView/dto/UserReissueRequestDto.java
+++ b/morib/src/main/java/org/morib/server/api/loginView/dto/UserReissueRequestDto.java
@@ -1,0 +1,6 @@
+package org.morib.server.api.loginView.dto;
+
+public record UserReissueRequestDto (
+        Long userId
+) {
+}

--- a/morib/src/main/java/org/morib/server/api/loginView/facade/UserAuthFacade.java
+++ b/morib/src/main/java/org/morib/server/api/loginView/facade/UserAuthFacade.java
@@ -1,0 +1,50 @@
+package org.morib.server.api.loginView.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.morib.server.annotation.Facade;
+import org.morib.server.domain.user.UserManager;
+import org.morib.server.domain.user.application.dto.ReissueTokenServiceDto;
+import org.morib.server.domain.user.application.service.DeleteUserService;
+import org.morib.server.domain.user.application.service.FetchUserService;
+import org.morib.server.domain.user.application.service.ReissueTokenService;
+import org.morib.server.domain.user.infra.User;
+import org.morib.server.global.exception.UnauthorizedException;
+import org.morib.server.global.message.ErrorMessage;
+import org.morib.server.global.oauth2.service.CustomOAuth2UserService;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+@RequiredArgsConstructor
+@Facade
+public class UserAuthFacade {
+
+    private final ReissueTokenService reissueTokenService;
+    private final FetchUserService fetchUserService;
+    private final DeleteUserService deleteUserService;
+    private final UserManager userManager;
+    private final CustomOAuth2UserService customOAuth2UserService;
+
+    public ReissueTokenServiceDto reissue(String refreshToken) {
+        return reissueTokenService.reissue(refreshToken);
+    }
+
+    // TODO : 이후 google rtk 무효화 로직 추가
+    @Transactional
+    public void logout(Long userId) {
+        User findUser = fetchUserService.fetchByUserId(userId);
+        userManager.invalidateRefreshToken(findUser);
+    }
+
+    @Transactional
+    public void withdraw(Long userId) {
+        User findUser = fetchUserService.fetchByUserId(userId);
+        customOAuth2UserService.withdrawInGoogle(findUser.getRefreshToken());
+        deleteUserService.delete(userId);
+    }
+
+
+}

--- a/morib/src/main/java/org/morib/server/domain/user/UserManager.java
+++ b/morib/src/main/java/org/morib/server/domain/user/UserManager.java
@@ -11,4 +11,13 @@ public class UserManager {
         findUser.updateProfile(updateUserProfileServiceDto.name(), updateUserProfileServiceDto.imageUrl(), updateUserProfileServiceDto.isPushEnabled());
     }
 
+    public void updateSocialRefreshToken(User findUser, String socialRefreshToken) {
+        findUser.updateSocialRefreshToken(socialRefreshToken);
+    }
+
+    public void invalidateRefreshToken(User findUser) {
+        findUser.invalidateRefreshToken();
+    }
+
+
 }

--- a/morib/src/main/java/org/morib/server/domain/user/application/dto/ReissueTokenServiceDto.java
+++ b/morib/src/main/java/org/morib/server/domain/user/application/dto/ReissueTokenServiceDto.java
@@ -1,0 +1,10 @@
+package org.morib.server.domain.user.application.dto;
+
+public record ReissueTokenServiceDto(
+        String accessToken,
+        String refreshToken
+) {
+    public static ReissueTokenServiceDto of(String accessToken, String refreshToken) {
+        return new ReissueTokenServiceDto(accessToken, refreshToken);
+    }
+}

--- a/morib/src/main/java/org/morib/server/domain/user/application/service/DeleteUserService.java
+++ b/morib/src/main/java/org/morib/server/domain/user/application/service/DeleteUserService.java
@@ -1,0 +1,5 @@
+package org.morib.server.domain.user.application.service;
+
+public interface DeleteUserService {
+    void delete(Long userId);
+}

--- a/morib/src/main/java/org/morib/server/domain/user/application/service/DeleteUserServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/user/application/service/DeleteUserServiceImpl.java
@@ -1,0 +1,23 @@
+package org.morib.server.domain.user.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.morib.server.domain.user.infra.User;
+import org.morib.server.domain.user.infra.UserRepository;
+import org.morib.server.global.exception.NotFoundException;
+import org.morib.server.global.message.ErrorMessage;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class DeleteUserServiceImpl implements DeleteUserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public void delete(Long userId) {
+        User findUser = userRepository.findById(userId).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.NOT_FOUND)
+        );
+        userRepository.delete(findUser);
+    }
+}

--- a/morib/src/main/java/org/morib/server/domain/user/application/service/ReissueTokenService.java
+++ b/morib/src/main/java/org/morib/server/domain/user/application/service/ReissueTokenService.java
@@ -1,0 +1,8 @@
+package org.morib.server.domain.user.application.service;
+
+
+import org.morib.server.domain.user.application.dto.ReissueTokenServiceDto;
+
+public interface ReissueTokenService {
+    ReissueTokenServiceDto reissue(String refreshToken);
+}

--- a/morib/src/main/java/org/morib/server/domain/user/application/service/ReissueTokenServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/user/application/service/ReissueTokenServiceImpl.java
@@ -1,0 +1,29 @@
+package org.morib.server.domain.user.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.morib.server.domain.user.application.dto.ReissueTokenServiceDto;
+import org.morib.server.domain.user.infra.User;
+import org.morib.server.domain.user.infra.UserRepository;
+import org.morib.server.global.exception.NotFoundException;
+import org.morib.server.global.jwt.JwtService;
+import org.morib.server.global.message.ErrorMessage;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReissueTokenServiceImpl implements ReissueTokenService{
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+
+    public ReissueTokenServiceDto reissue(String refreshToken) {
+        jwtService.isTokenValid(refreshToken);
+        User findUser = userRepository.findByRefreshToken(refreshToken).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.NOT_FOUND)
+        );
+        String newRefreshToken = jwtService.createRefreshToken();
+        jwtService.updateRefreshToken(findUser.getId(), newRefreshToken);
+        return ReissueTokenServiceDto.of(jwtService.createAccessToken(findUser.getId()), newRefreshToken);
+    }
+
+
+}

--- a/morib/src/main/java/org/morib/server/domain/user/infra/User.java
+++ b/morib/src/main/java/org/morib/server/domain/user/infra/User.java
@@ -11,6 +11,7 @@ import org.morib.server.domain.user.infra.type.Platform;
 import org.morib.server.domain.user.infra.type.Role;
 import org.morib.server.global.common.BaseTimeEntity;
 import org.morib.server.global.oauth2.userinfo.OAuth2UserInfo;
+import static org.morib.server.global.common.Constants.INVALID_REFRESH_TOKEN;
 
 import java.util.Set;
 
@@ -43,6 +44,7 @@ public class User extends BaseTimeEntity {
     private InterestArea interestArea;
 
     private String socialId; // 로그인한 소셜 타입의 식별자 값 (일반 로그인인 경우 null)
+    private String social_refreshToken;
     private boolean isPushEnabled;
     // 유저 권한 설정 메소드
     public void authorizeUser() {
@@ -62,6 +64,7 @@ public class User extends BaseTimeEntity {
                 .imageUrl(oauth2UserInfo.getImageUrl())
                 .role(Role.GUEST)
                 .isPushEnabled(false)
+                .social_refreshToken(null)
                 .build();
     }
 
@@ -71,5 +74,11 @@ public class User extends BaseTimeEntity {
         this.isPushEnabled = isPushEnabled;
     }
 
+    public void updateSocialRefreshToken(String socialRefreshToken) {
+        this.social_refreshToken = socialRefreshToken;
+    }
 
+    public void invalidateRefreshToken() {
+        this.refreshToken = INVALID_REFRESH_TOKEN;
+    }
 }

--- a/morib/src/main/java/org/morib/server/global/common/Constants.java
+++ b/morib/src/main/java/org/morib/server/global/common/Constants.java
@@ -12,4 +12,10 @@ public final class Constants {
     public static final String SEND = "send";
     public static final String RECEIVE = "receive";
     public static final String ADD_FRIEND_REQUEST_MSG = " 님이 친구 요청을 보냈습니다.";
+    public static final Long SSE_TIMEOUT = 180_000L;
+    public static final String IS_SIGN_UP_QUERYSTRING = "?isSignUp=";
+    public static final String GOOGLE_REGISTRATION_ID = "google";
+    public static final String INVALID_REFRESH_TOKEN = "invalid";
+    public static final String GOOGLE_REVOKE_URL = "https://oauth2.googleapis.com/revoke";
+
 }

--- a/morib/src/main/java/org/morib/server/global/config/CustomAuthorizationRequestResolver.java
+++ b/morib/src/main/java/org/morib/server/global/config/CustomAuthorizationRequestResolver.java
@@ -1,0 +1,61 @@
+package org.morib.server.global.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Component
+public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+
+    private final OAuth2AuthorizationRequestResolver defaultAuthorizationRequestResolver;
+
+    public CustomAuthorizationRequestResolver(
+            ClientRegistrationRepository clientRegistrationRepository) {
+
+        this.defaultAuthorizationRequestResolver =
+                new DefaultOAuth2AuthorizationRequestResolver(
+                        clientRegistrationRepository, "/oauth2/authorization");
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        OAuth2AuthorizationRequest authorizationRequest =
+                this.defaultAuthorizationRequestResolver.resolve(request);
+
+        return authorizationRequest != null ?
+                customAuthorizationRequest(authorizationRequest) :
+                null;
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(
+            HttpServletRequest request, String clientRegistrationId) {
+
+        OAuth2AuthorizationRequest authorizationRequest =
+                this.defaultAuthorizationRequestResolver.resolve(
+                        request, clientRegistrationId);
+
+        return authorizationRequest != null ?
+                customAuthorizationRequest(authorizationRequest) :
+                null;
+    }
+
+    private OAuth2AuthorizationRequest customAuthorizationRequest(
+            OAuth2AuthorizationRequest authorizationRequest) {
+
+        Map<String, Object> additionalParameters =
+                new LinkedHashMap<>(authorizationRequest.getAdditionalParameters());
+        additionalParameters.put("access_type", "offline");
+        additionalParameters.put("prompt", "consent");
+
+        return OAuth2AuthorizationRequest.from(authorizationRequest)
+                .additionalParameters(additionalParameters)
+                .build();
+    }
+}

--- a/morib/src/main/java/org/morib/server/global/jwt/JwtService.java
+++ b/morib/src/main/java/org/morib/server/global/jwt/JwtService.java
@@ -100,8 +100,7 @@ public class JwtService {
             return Optional.of(claims.get(ID_CLAIM, Integer.class).toString());
 
         } catch (Exception e) {
-            log.error("액세스 토큰이 유효하지 않습니다.");
-            return Optional.empty();
+            throw new UnauthorizedException(ErrorMessage.INVALID_TOKEN);
         }
     }
 

--- a/morib/src/main/java/org/morib/server/global/message/ErrorMessage.java
+++ b/morib/src/main/java/org/morib/server/global/message/ErrorMessage.java
@@ -15,12 +15,14 @@ public enum ErrorMessage {
     TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "잘못된 형식입니다"),
     INVALID_URL(HttpStatus.BAD_REQUEST, "요청된 url이 유효하지 않습니다."),
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, "유효하지 않은 이메일 형식입니다."),
+
     /**
      * 401 Unauthorized
      */
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
     JWT_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "사용자의 로그인 검증을 실패했습니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효한 토큰이 아닙니다"),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효한 토큰이 아닙니다."),
+    FAILED_WITHDRAW(HttpStatus.UNAUTHORIZED, "회원 탈퇴에 실패했습니다."),
 
     /**
      * 403 Forbidden
@@ -46,7 +48,8 @@ public enum ErrorMessage {
     /**
      * 500 Internal Server Error
      */
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+    SSE_CONNECT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SSE 연결에 실패했습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/morib/src/main/java/org/morib/server/global/oauth2/CustomOAuth2User.java
+++ b/morib/src/main/java/org/morib/server/global/oauth2/CustomOAuth2User.java
@@ -13,12 +13,16 @@ public class CustomOAuth2User extends DefaultOAuth2User {
 
     private Role role;
     private Long userId;
+    private String registrationId;
+    private String principalName;
 
     public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities,
                             Map<String, Object> attributes, String nameAttributeKey,
-                            Role role, Long userId) {
+                            Role role, Long userId, String registrationId, String principalName) {
         super(authorities, attributes, nameAttributeKey);
         this.role = role;
         this.userId = userId;
+        this.registrationId = registrationId;
+        this.principalName = principalName;
     }
 }

--- a/morib/src/main/java/org/morib/server/global/oauth2/handler/CustomLogoutHandler.java
+++ b/morib/src/main/java/org/morib/server/global/oauth2/handler/CustomLogoutHandler.java
@@ -1,0 +1,29 @@
+package org.morib.server.global.oauth2.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.morib.server.api.loginView.facade.UserAuthFacade;
+import org.morib.server.global.exception.UnauthorizedException;
+import org.morib.server.global.jwt.JwtService;
+import org.morib.server.global.message.ErrorMessage;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomLogoutHandler implements LogoutHandler {
+
+    private final JwtService jwtService;
+    private final UserAuthFacade userAuthFacade;
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        String accessToken = jwtService.extractAccessToken(request).orElseThrow(
+                () -> new UnauthorizedException(ErrorMessage.INVALID_TOKEN)
+        );
+        Long userId = Long.valueOf(jwtService.extractId(accessToken).get());
+        userAuthFacade.logout(userId);
+    }
+}

--- a/morib/src/main/java/org/morib/server/global/oauth2/handler/CustomLogoutSuccessHandler.java
+++ b/morib/src/main/java/org/morib/server/global/oauth2/handler/CustomLogoutSuccessHandler.java
@@ -1,0 +1,23 @@
+package org.morib.server.global.oauth2.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Service
+public class CustomLogoutSuccessHandler implements LogoutSuccessHandler {
+
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json");
+        response.getWriter().write("status : 200 \n message: 요청이 성공했습니다.");
+    }
+}

--- a/morib/src/main/java/org/morib/server/global/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/morib/src/main/java/org/morib/server/global/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -5,14 +5,16 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.morib.server.domain.user.UserManager;
+import org.morib.server.domain.user.application.service.FetchUserService;
 import org.morib.server.domain.user.infra.User;
 import org.morib.server.domain.user.infra.UserRepository;
 import org.morib.server.domain.user.infra.type.Role;
 import org.morib.server.global.common.ApiResponseUtil;
+import org.morib.server.global.common.SecretProperties;
 import org.morib.server.global.common.TokenResponseDto;
 import org.morib.server.global.exception.NotFoundException;
 import org.morib.server.global.exception.UnauthorizedException;
@@ -21,12 +23,16 @@ import org.morib.server.global.message.ErrorMessage;
 import org.morib.server.global.message.SuccessMessage;
 import org.morib.server.global.oauth2.CustomOAuth2User;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
-import static org.morib.server.global.common.Constants.REFRESH_TOKEN_SUBJECT;
+import static org.morib.server.global.common.Constants.*;
 
 @Slf4j
 @Component
@@ -34,33 +40,60 @@ import static org.morib.server.global.common.Constants.REFRESH_TOKEN_SUBJECT;
 public class  OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtService jwtService;
+    private final FetchUserService fetchUserService;
+    private final UserManager userManager;
     private final UserRepository userRepository;
     private final ObjectMapper objectMapper;
+    private final OAuth2AuthorizedClientService oAuth2AuthorizedClientService;
+    private final SecretProperties secretProperties;
 
     @Override
     @Transactional
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         log.info("OAuth2 Login 성공!");
+        boolean isSignUp = false;
         try {
             CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
             if(oAuth2User.getRole() == Role.GUEST) { // 회원 가입
                 User findUser = userRepository.findById(oAuth2User.getUserId())
                         .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
                 findUser.authorizeUser();
+                isSignUp = true;
             }
-            loginSuccess(response, oAuth2User);
+            loginSuccess(response, oAuth2User, isSignUp);
         } catch (Exception e) {
             throw new UnauthorizedException(ErrorMessage.INVALID_TOKEN);
         }
+
     }
 
-    private void loginSuccess(HttpServletResponse response, CustomOAuth2User oAuth2User) throws IOException {
+    private void loginSuccess(HttpServletResponse response, CustomOAuth2User oAuth2User, boolean isSignUp) throws IOException {
         String accessToken = jwtService.createAccessToken(oAuth2User.getUserId());
         String refreshToken = jwtService.createRefreshToken();
         jwtService.updateRefreshToken(oAuth2User.getUserId(), refreshToken);
-        response.setContentType("application/json;charset=UTF-8");
-        response.setStatus(HttpServletResponse.SC_OK);
-        response.addCookie(new Cookie(REFRESH_TOKEN_SUBJECT, refreshToken));
-        response.getWriter().write(objectMapper.writeValueAsString(ApiResponseUtil.success(SuccessMessage.SUCCESS, TokenResponseDto.of(accessToken, oAuth2User.getUserId())).getBody()));
+        userManager.updateSocialRefreshToken(
+                fetchUserService.fetchByUserId(
+                        oAuth2User.getUserId()), getSocialRefreshTokenByAuthorizedClient(oAuth2User.getRegistrationId(), oAuth2User.getPrincipalName()));
+        StringBuilder redirectUri = new StringBuilder(secretProperties.getClientRedirectUriProd());
+        redirectUri.append(IS_SIGN_UP_QUERYSTRING).append(isSignUp);
+        response.addCookie(getCookieForToken(ACCESS_TOKEN_SUBJECT, accessToken));
+        response.addCookie(getCookieForToken(REFRESH_TOKEN_SUBJECT, refreshToken));
+        response.sendRedirect(redirectUri.toString());
+    }
+
+    private String getSocialRefreshTokenByAuthorizedClient(String registrationId, String principalName) {
+        OAuth2AuthorizedClient user = oAuth2AuthorizedClientService.loadAuthorizedClient(registrationId, principalName);
+        OAuth2RefreshToken refreshToken = user.getRefreshToken();
+        return refreshToken.getTokenValue();
+    }
+
+    private Cookie getCookieForToken(String sub, String token) {
+        Cookie cookie = new Cookie(sub, token);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setDomain(secretProperties.getClientRedirectUriProd()); // 쿠키를 사용할 도메인
+        cookie.setAttribute("SameSite", "None");
+        return cookie;
     }
 }

--- a/morib/src/main/java/org/morib/server/global/oauth2/service/CustomOAuth2UserService.java
+++ b/morib/src/main/java/org/morib/server/global/oauth2/service/CustomOAuth2UserService.java
@@ -81,4 +81,22 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         User createdUser = User.createByOAuth2UserInfo(platform, attributes.getOauth2UserInfo());
         return userRepository.saveAndFlush(createdUser);
     }
+
+    public void withdrawInGoogle(String refreshToken) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Content-Type", "application/x-www-form-urlencoded");
+        String requestBody = "token=" + refreshToken;
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                GOOGLE_REVOKE_URL,
+                HttpMethod.POST,
+                new HttpEntity<>(requestBody, headers),
+                String.class
+        );
+
+        if (!response.getStatusCode().is2xxSuccessful()) {
+            throw new UnauthorizedException(ErrorMessage.FAILED_WITHDRAW);
+        }
+    }
 }

--- a/morib/src/main/java/org/morib/server/global/oauth2/service/CustomOAuth2UserService.java
+++ b/morib/src/main/java/org/morib/server/global/oauth2/service/CustomOAuth2UserService.java
@@ -5,18 +5,31 @@ import lombok.extern.slf4j.Slf4j;
 import org.morib.server.domain.user.infra.User;
 import org.morib.server.domain.user.infra.UserRepository;
 import org.morib.server.domain.user.infra.type.Platform;
+import org.morib.server.global.exception.UnauthorizedException;
+import org.morib.server.global.message.ErrorMessage;
 import org.morib.server.global.oauth2.CustomOAuth2User;
 import org.morib.server.global.oauth2.OAuthAttributes;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
 import java.util.Collections;
 import java.util.Map;
+
+import static org.morib.server.global.common.Constants.GOOGLE_REVOKE_URL;
 
 @Slf4j
 @Service
@@ -32,6 +45,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
         OAuth2User oAuth2User = delegate.loadUser(userRequest);
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String principalName = (String) oAuth2User.getAttributes().get("sub");
         Platform platform = getSocialType(registrationId);
         String userNameAttributeName = userRequest.getClientRegistration()
                 .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
@@ -43,7 +57,9 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
                 attributes,
                 extractAttributes.getNameAttributeKey(),
                 createdUser.getRole(),
-                createdUser.getId()
+                createdUser.getId(),
+                registrationId,
+                principalName
         );
     }
 


### PR DESCRIPTION
## 📍 Issue
- closes #102 

## ✨ Key Changes
인증 관련 작업 전부 진행했습니다.
회원 탈퇴의 경우 Spring Security에서 지원하지 않아서 RestTemplate로 구글 api로 revoke 진행했습니다.


## 💬 To Reviewers
