### PR TITLE
Refactor [#113] SSE 관련 클래스 아키텍처 리팩토링

### DIFF
--- a/morib/src/main/java/org/morib/server/api/timerView/dto/StopTimerRequestDto.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/dto/StopTimerRequestDto.java
@@ -2,5 +2,10 @@ package org.morib.server.api.timerView.dto;
 
 import java.time.LocalDate;
 
-public record StopTimerRequestDto(LocalDate targetDate, int elapsedTime) {
+public record StopTimerRequestDto(
+        LocalDate targetDate,
+        int elapsedTime,
+        String runningCategoryName,
+        Long taskId
+) {
 }

--- a/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
@@ -9,8 +9,6 @@ import org.morib.server.annotation.Facade;
 import org.morib.server.api.modalView.dto.FetchRelationshipResponseDto;
 import org.morib.server.api.modalView.facade.ModalViewFacade;
 import org.morib.server.api.timerView.dto.*;
-import org.morib.server.domain.category.application.FetchCategoryService;
-import org.morib.server.domain.category.infra.Category;
 import org.morib.server.domain.relationship.application.FetchRelationshipService;
 import org.morib.server.domain.relationship.infra.Relationship;
 import org.morib.server.domain.task.application.FetchTaskService;
@@ -21,15 +19,13 @@ import org.morib.server.domain.timer.infra.Timer;
 import org.morib.server.domain.todo.application.FetchTodoService;
 import org.morib.server.domain.todo.infra.Todo;
 import org.morib.server.domain.user.application.service.FetchUserService;
-import org.morib.server.domain.user.infra.User;
-import org.morib.server.global.sse.SseFacade;
-import org.morib.server.global.sse.SseService;
-import org.morib.server.global.sse.UserInfoDtoForSseUserInfoWrapper;
+import org.morib.server.global.sse.api.SseFacade;
+import org.morib.server.global.sse.application.service.SseService;
+import org.morib.server.global.sse.api.UserInfoDtoForSseUserInfoWrapper;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import static org.morib.server.global.common.Constants.SSE_EVENT_REFRESH;
-import static org.morib.server.global.common.Constants.SSE_EVENT_USER_INFO_UPDATE;
+import static org.morib.server.global.common.Constants.*;
 
 
 @Facade
@@ -51,7 +47,7 @@ public class TimerViewFacade {
         SseEmitter emitter = sseService.fetchSseEmitterByUserId(userId);
         sseService.saveSseUserInfo(userId, emitter, calculatedSseUserInfoWrapper);
         List<Relationship> relationships = fetchRelationshipService.fetchConnectedRelationship(userId);
-        sseService.broadcast(userId, calculatedSseUserInfoWrapper, SSE_EVENT_USER_INFO_UPDATE, relationships);
+        sseService.broadcast(userId, calculatedSseUserInfoWrapper, SSE_EVENT_TIMER_START, relationships);
     }
 
     public void stopAfterSumElapsedTime(Long userId, Long taskId, StopTimerRequestDto dto) {
@@ -68,7 +64,7 @@ public class TimerViewFacade {
         SseEmitter emitter = sseService.fetchSseEmitterByUserId(userId);
         sseService.saveSseUserInfo(userId, emitter, calculatedSseUserInfoWrapper);
         List<Relationship> relationships = fetchRelationshipService.fetchConnectedRelationship(userId);
-        sseService.broadcast(userId, calculatedSseUserInfoWrapper, SSE_EVENT_USER_INFO_UPDATE, relationships);
+        sseService.broadcast(userId, calculatedSseUserInfoWrapper, SSE_EVENT_TIMER_STOP_ACTION, relationships);
     }
 
     /**

--- a/morib/src/main/java/org/morib/server/domain/relationship/application/FetchRelationshipService.java
+++ b/morib/src/main/java/org/morib/server/domain/relationship/application/FetchRelationshipService.java
@@ -10,6 +10,5 @@ public interface FetchRelationshipService {
     List<Relationship> fetchConnectedRelationship(Long userId);
     List<Relationship> fetchUnconnectedRelationship(Long userId);
     Relationship fetchRelationshipByUserIdAndFriendId(Long userId, Long friendId, RelationLevel relationLevel);
-
-
+    List<Long> fetchConnectedRelationshipAndClassify(Long userId);
 }

--- a/morib/src/main/java/org/morib/server/domain/relationship/application/FetchRelationshipServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/relationship/application/FetchRelationshipServiceImpl.java
@@ -11,7 +11,9 @@ import org.morib.server.global.exception.NotFoundException;
 import org.morib.server.global.message.ErrorMessage;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -35,4 +37,15 @@ public class FetchRelationshipServiceImpl implements FetchRelationshipService {
                 () -> new NotFoundException(ErrorMessage.NOT_FOUND)
         );
     }
+
+    @Override
+    public List<Long> fetchConnectedRelationshipAndClassify(Long userId) {
+        return relationshipRepository.findByUserIdOrFriendIdAndRelationLevel(userId, RelationLevel.CONNECTED)
+                .stream()
+                .map(relationship -> relationship.getUser().getId().equals(userId)
+                        ? relationship.getFriend().getId()
+                        : relationship.getUser().getId())
+                .toList();
+    }
+
 }

--- a/morib/src/main/java/org/morib/server/domain/timer/application/CreateTimerService.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/application/CreateTimerService.java
@@ -1,0 +1,10 @@
+package org.morib.server.domain.timer.application;
+
+import org.morib.server.domain.task.infra.Task;
+import org.morib.server.domain.user.infra.User;
+
+import java.time.LocalDate;
+
+public interface CreateTimerService {
+    void createTimer(User user, LocalDate targetDate, Task task);
+}

--- a/morib/src/main/java/org/morib/server/domain/timer/application/CreateTimerServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/application/CreateTimerServiceImpl.java
@@ -1,0 +1,23 @@
+package org.morib.server.domain.timer.application;
+
+import lombok.RequiredArgsConstructor;
+import org.morib.server.domain.category.infra.Category;
+import org.morib.server.domain.task.infra.Task;
+import org.morib.server.domain.timer.infra.Timer;
+import org.morib.server.domain.timer.infra.TimerRepository;
+import org.morib.server.domain.user.infra.User;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class CreateTimerServiceImpl implements CreateTimerService{
+
+    private final TimerRepository timerRepository;
+
+    @Override
+    public void createTimer(User user, LocalDate targetDate, Task task) {
+        timerRepository.save(Timer.create(user, targetDate, task));
+    }
+}

--- a/morib/src/main/java/org/morib/server/domain/timer/application/FetchTimerService.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/application/FetchTimerService.java
@@ -2,6 +2,7 @@ package org.morib.server.domain.timer.application;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.morib.server.domain.task.infra.Task;
@@ -10,12 +11,9 @@ import org.morib.server.domain.user.infra.User;
 
 public interface FetchTimerService {
     Timer fetchByTaskAndTargetDate(Task findTask, LocalDate localDate);
-
     int fetchElapsedTimeOrZeroByTaskAndTargetDate(Task findTask, LocalDate targetDate);
-
     int sumOneTaskElapsedTimeInTargetDate(Task t, LocalDate targetDate);
-
     List<Timer> fetchByUserAndTargetDate(User user, LocalDate targetDate);
-
     int sumElapsedTimeByUser(User user, LocalDate targetDate);
+    Set<Long> fetchExistingTaskIdsByTargetDate(Set<Task> tasks, LocalDate targetDate);
 }

--- a/morib/src/main/java/org/morib/server/domain/timer/application/FetchTimerServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/application/FetchTimerServiceImpl.java
@@ -2,6 +2,8 @@ package org.morib.server.domain.timer.application;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import lombok.RequiredArgsConstructor;
 import org.morib.server.domain.task.infra.Task;
@@ -21,9 +23,11 @@ public class FetchTimerServiceImpl implements FetchTimerService{
     @Override
     public Timer fetchByTaskAndTargetDate(Task findTask, LocalDate targetDate) {
         return findTask.getTimers().stream()
-                .filter(timer -> timer.getTargetDate().equals(targetDate))
-                .findFirst().orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+                .filter(timer -> timer.getTargetDate().isEqual(targetDate))
+                .findFirst()
+                .orElse(null); // Timer가 없으면 null 반환
     }
+
 
     @Override
     public int fetchElapsedTimeOrZeroByTaskAndTargetDate(Task findTask, LocalDate targetDate) {
@@ -53,6 +57,14 @@ public class FetchTimerServiceImpl implements FetchTimerService{
     @Override
     public List<Timer> fetchByUserAndTargetDate(User user, LocalDate targetDate) {
         return timerRepository.findByUserAndTargetDate(user, targetDate);
+    }
+
+    @Override
+    public Set<Long> fetchExistingTaskIdsByTargetDate(Set<Task> tasks, LocalDate targetDate) {
+        List<Long> taskIds = tasks.stream()
+                .map(Task::getId)
+                .toList(); // Task ID 리스트 변환
+        return timerRepository.findExistingTaskIdsByTargetDate(taskIds, targetDate);
     }
 
 }

--- a/morib/src/main/java/org/morib/server/domain/timer/infra/Timer.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/infra/Timer.java
@@ -1,13 +1,11 @@
 package org.morib.server.domain.timer.infra;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.morib.server.domain.category.infra.Category;
 import org.morib.server.domain.task.infra.Task;
 
+import java.sql.Time;
 import java.time.LocalDate;
 import org.morib.server.domain.user.infra.User;
 import org.morib.server.global.common.BaseTimeEntity;
@@ -15,6 +13,8 @@ import org.morib.server.global.common.BaseTimeEntity;
 @Entity
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Timer extends BaseTimeEntity {
     @Id
@@ -36,5 +36,13 @@ public class Timer extends BaseTimeEntity {
 
     public void addElapsedTime(int i) {
         this.elapsedTime += i;
+    }
+
+    public static Timer create(User user, LocalDate targetDate, Task task) {
+        return Timer.builder()
+                .user(user)
+                .targetDate(targetDate)
+                .task(task)
+                .build();
     }
 }

--- a/morib/src/main/java/org/morib/server/domain/timer/infra/TimerRepository.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/infra/TimerRepository.java
@@ -3,14 +3,16 @@ package org.morib.server.domain.timer.infra;
 import java.util.List;
 import org.morib.server.domain.user.infra.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.util.Set;
 
 public interface TimerRepository extends JpaRepository<Timer, Long> {
     List<Timer> findByUserAndTargetDate(User user, LocalDate targetDate);
-
-
     List<Timer> findByUser(User user);
+    @Query("SELECT t.task.id FROM Timer t WHERE t.task.id IN :taskIds AND t.targetDate = :targetDate")
+    Set<Long> findExistingTaskIdsByTargetDate(List<Long> taskIds, LocalDate targetDate);
 
 }

--- a/morib/src/main/java/org/morib/server/global/common/Constants.java
+++ b/morib/src/main/java/org/morib/server/global/common/Constants.java
@@ -7,20 +7,26 @@ public final class Constants {
 
     public static final String AUTHORIZATION = "Authorization";
     public static final String BEARER = "Bearer ";
-    public static final String ACCESS_TOKEN_SUBJECT = "access_token";
-    public static final String REFRESH_TOKEN_SUBJECT = "refresh_token";
+    public static final String ACCESS_TOKEN_SUBJECT = "accessToken";
+    public static final String REFRESH_TOKEN_SUBJECT = "refreshToken";
     public static final String ID_CLAIM = "id";
     public static final String SEND = "send";
     public static final String RECEIVE = "receive";
-    public static final String ADD_FRIEND_REQUEST_MSG = " 님이 친구 요청을 보냈습니다.";
-    public static final Long SSE_TIMEOUT = 180_000L;
+    public static final Long SSE_TIMEOUT = 300_000L;
     public static final String IS_SIGN_UP_QUERYSTRING = "?isSignUp=";
     public static final String GOOGLE_REGISTRATION_ID = "google";
     public static final String INVALID_REFRESH_TOKEN = "invalid";
     public static final String GOOGLE_REVOKE_URL = "https://oauth2.googleapis.com/revoke";
+
     public static final String SSE_EVENT_CONNECT = "connect";
     public static final String SSE_EVENT_COMPLETION = "completion";
     public static final String SSE_EVENT_REFRESH = "refresh";
-    public static final String SSE_EVENT_USER_INFO_UPDATE = "update";
+    public static final String SSE_EVENT_TIME_OUT = "timeout";
+    public static final String SSE_EVENT_TIMER_START = "timerStart";
+    public static final String SSE_EVENT_TIMER_STOP_ACTION = "timerStopAction";
+    public static final String SSE_EVENT_FRIEND_REQUEST = "friendRequest";
+    public static final String SSE_EVENT_FRIEND_REQUEST_ACCEPT = "friendRequestAccept";
+
+
 
 }

--- a/morib/src/main/java/org/morib/server/global/common/HealthCheckController.java
+++ b/morib/src/main/java/org/morib/server/global/common/HealthCheckController.java
@@ -1,0 +1,14 @@
+package org.morib.server.global.common;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class HealthCheckController {
+    @GetMapping("/profile")
+    public String getProfile() {
+        return "UP";
+    }
+}

--- a/morib/src/main/java/org/morib/server/global/message/SseMessageBuilder.java
+++ b/morib/src/main/java/org/morib/server/global/message/SseMessageBuilder.java
@@ -1,0 +1,32 @@
+package org.morib.server.global.message;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class SseMessageBuilder {
+
+    public String buildConnectionMessage(Long userId) {
+        return "[id : " + userId + "] 가 연결되었습니다.";
+    }
+
+    public String buildDisconnectionMessage(Long userId) {
+        return "[id : " + userId + "] 과의 연결이 종료되었습니다.";
+    }
+
+    public String buildTimeoutMessage(Long userId) {
+        return "[id : " + userId + "] 님의 연결 유지 시간이 만료되었습니다.";
+    }
+
+    public String buildFriendRequestMessage(String userName) {
+        return userName + " 님이 친구 요청을 보냈습니다.";
+    }
+
+    public String buildFriendRequestAcceptMessage(String userName) {
+        return userName + " 님이 친구 요청을 수락했습니다.";
+    }
+
+
+}

--- a/morib/src/main/java/org/morib/server/global/sse/api/SseController.java
+++ b/morib/src/main/java/org/morib/server/global/sse/api/SseController.java
@@ -1,29 +1,12 @@
-package org.morib.server.global.sse;
+package org.morib.server.global.sse.api;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.morib.server.api.homeView.dto.fetch.FetchMyElapsedTimeResponseDto;
-import org.morib.server.api.homeView.facade.HomeViewFacade;
-import org.morib.server.domain.relationship.application.FetchRelationshipService;
-import org.morib.server.domain.relationship.infra.Relationship;
-import org.morib.server.domain.task.application.FetchTaskService;
-import org.morib.server.domain.task.infra.Task;
-import org.morib.server.domain.timer.TimerManager;
-import org.morib.server.domain.timer.application.FetchTimerService;
-import org.morib.server.domain.timer.infra.Timer;
-import org.morib.server.global.exception.SSEConnectionException;
-import org.morib.server.global.message.ErrorMessage;
-import org.morib.server.global.userauth.PrincipalHandler;
+import org.morib.server.global.sse.application.service.SseService;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-
-import java.io.IOException;
-import java.time.LocalDate;
-import java.util.List;
-
-import static org.morib.server.global.common.Constants.SSE_TIMEOUT;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,7 +23,7 @@ public class SseController {
                                                 @PathVariable("userId") Long userId
                                                 ){
 //        Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
-        SseEmitter emitter = sseService.init(userId);
+        SseEmitter emitter = sseFacade.init(userId);
         return ResponseEntity.ok(emitter);
     }
 

--- a/morib/src/main/java/org/morib/server/global/sse/api/SseEventHandler.java
+++ b/morib/src/main/java/org/morib/server/global/sse/api/SseEventHandler.java
@@ -1,0 +1,44 @@
+package org.morib.server.global.sse.api;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.morib.server.domain.relationship.application.FetchRelationshipService;
+import org.morib.server.global.message.SseMessageBuilder;
+import org.morib.server.global.sse.application.event.SseDisconnectEvent;
+import org.morib.server.global.sse.application.event.SseTimeoutEvent;
+import org.morib.server.global.sse.application.service.SseSender;
+import org.morib.server.global.sse.application.service.SseService;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
+
+import static org.morib.server.global.common.Constants.*;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class SseEventHandler {
+
+    private final SseService sseService;
+    private final SseSender sseSender;
+    private final SseMessageBuilder sseMessageBuilder;
+    private final FetchRelationshipService fetchRelationshipService;
+
+    @EventListener
+    public void handleSseCompletion(SseDisconnectEvent event) {
+        log.info("SseDisconnectEvent received for userId: {}", event.getUserId());
+        List<Long> targetUserIds = fetchRelationshipService.fetchConnectedRelationshipAndClassify(event.getUserId());
+        List<SseEmitter> targetEmitters = sseService.fetchConnectedSseEmittersById(targetUserIds);
+        sseSender.broadcast(targetEmitters, SSE_EVENT_COMPLETION, sseMessageBuilder.buildDisconnectionMessage(event.getUserId()));
+    }
+
+    @EventListener
+    public void handleSseTimeout(SseTimeoutEvent event) {
+        log.info("SseTimeoutEvent received for userId: {}", event.getUserId());
+        List<Long> targetUserIds = fetchRelationshipService.fetchConnectedRelationshipAndClassify(event.getUserId());
+        List<SseEmitter> targetEmitters = sseService.fetchConnectedSseEmittersById(targetUserIds);
+        sseSender.broadcast(targetEmitters, SSE_EVENT_TIME_OUT, sseMessageBuilder.buildTimeoutMessage(event.getUserId()));
+    }
+}

--- a/morib/src/main/java/org/morib/server/global/sse/api/SseFacade.java
+++ b/morib/src/main/java/org/morib/server/global/sse/api/SseFacade.java
@@ -1,4 +1,4 @@
-package org.morib.server.global.sse;
+package org.morib.server.global.sse.api;
 
 import lombok.RequiredArgsConstructor;
 import org.morib.server.annotation.Facade;
@@ -10,11 +10,16 @@ import org.morib.server.domain.task.infra.Task;
 import org.morib.server.domain.timer.TimerManager;
 import org.morib.server.domain.timer.application.FetchTimerService;
 import org.morib.server.domain.timer.infra.Timer;
+import org.morib.server.global.message.SseMessageBuilder;
+import org.morib.server.global.sse.application.repository.SseRepository;
+import org.morib.server.global.sse.application.service.SseSender;
+import org.morib.server.global.sse.application.service.SseService;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.LocalDate;
 import java.util.List;
 
+import static org.morib.server.global.common.Constants.SSE_EVENT_CONNECT;
 import static org.morib.server.global.common.Constants.SSE_EVENT_REFRESH;
 
 @Facade
@@ -27,46 +32,43 @@ public class SseFacade {
     private final FetchRelationshipService fetchRelationshipService;
     private final TimerManager timerManager;
     private final HomeViewFacade homeViewFacade;
-    private final SseRepository sseRepository;
+    private final SseSender sseSender;
+    private final SseMessageBuilder sseMessageBuilder;
+
+    public SseEmitter init(Long userId) {
+        SseEmitter createdEmitter = sseService.create();
+        sseService.add(userId, createdEmitter);
+        return broadcastAllAfterCreated(userId, createdEmitter, SSE_EVENT_CONNECT);
+    }
 
     public SseEmitter refresh(Long userId, UserInfoDtoForSseUserInfoWrapper userInfoDtoForSseUserInfoWrapper) {
-        // 1. emitter 재생성
-        SseEmitter emitter = sseService.create();
-
-        // 2. dto로 전달받은 task의 elapsedTime, taskId, runningCategoryName SseUserInfoWrapper에 세팅
+        SseEmitter createdEmitter = sseService.create();
         UserInfoDtoForSseUserInfoWrapper calculatedSseUserInfoWrapper = update(userId, userInfoDtoForSseUserInfoWrapper);
+        sseService.saveSseUserInfo(userId, createdEmitter, calculatedSseUserInfoWrapper);
+        return broadcastAllAfterCreated(userId, createdEmitter, SSE_EVENT_REFRESH);
+    }
 
-        // 3. repository에 저장
-        sseService.saveSseUserInfo(userId, emitter, calculatedSseUserInfoWrapper);
-
-        // 4. broadcast
-        List<Relationship> relationships = fetchRelationshipService.fetchConnectedRelationship(userId);
-        sseRepository.broadcast(userId, calculatedSseUserInfoWrapper, SSE_EVENT_REFRESH, relationships);
-
-        return emitter;
+    public SseEmitter broadcastAllAfterCreated(Long userId, SseEmitter createdEmitter, String sseEventMessage) {
+        sseSender.sendEvent(createdEmitter, sseEventMessage, sseMessageBuilder.buildConnectionMessage(userId));
+        List<Long> targetUserIds = fetchRelationshipService.fetchConnectedRelationshipAndClassify(userId);
+        List<SseEmitter> targetEmitters = sseService.fetchConnectedSseEmittersById(targetUserIds);
+        sseSender.broadcast(targetEmitters, sseEventMessage, sseMessageBuilder.buildConnectionMessage(userId));
+        return createdEmitter;
     }
 
     public UserInfoDtoForSseUserInfoWrapper updateWhenTimerStart(Long userId, UserInfoDtoForSseUserInfoWrapper wrapper) {
-        // 1. Timer DB update (addElapsedTime)
         Task findTask = fetchTaskService.fetchById(wrapper.taskId());
         Timer timer = fetchTimerService.fetchByTaskAndTargetDate(findTask, LocalDate.now());
         timerManager.setElapsedTime(timer, wrapper.elapsedTime());
-
-        // 2. Emitter Value Update (categoryName, elapsedTime, taskId)
         int calculatedElapsedTime = homeViewFacade.fetchTotalElapsedTimeTodayByUser(userId, LocalDate.now()).sumTodayElapsedTime();
-
         return UserInfoDtoForSseUserInfoWrapper.of(userId, calculatedElapsedTime, wrapper.runningCategoryName(), wrapper.taskId());
     }
 
     public UserInfoDtoForSseUserInfoWrapper update(Long userId, UserInfoDtoForSseUserInfoWrapper wrapper) {
-        // 1. Timer DB update (addElapsedTime)
         Task findTask = fetchTaskService.fetchById(wrapper.taskId());
         Timer timer = fetchTimerService.fetchByTaskAndTargetDate(findTask, LocalDate.now());
         timerManager.addElapsedTime(timer, wrapper.elapsedTime());
-
-        // 2. Emitter Value Update (categoryName, elapsedTime, taskId)
         int calculatedElapsedTime = homeViewFacade.fetchTotalElapsedTimeTodayByUser(userId, LocalDate.now()).sumTodayElapsedTime();
-
         return UserInfoDtoForSseUserInfoWrapper.of(userId, calculatedElapsedTime, wrapper.runningCategoryName(), wrapper.taskId());
     }
 

--- a/morib/src/main/java/org/morib/server/global/sse/api/UserInfoDtoForSseUserInfoWrapper.java
+++ b/morib/src/main/java/org/morib/server/global/sse/api/UserInfoDtoForSseUserInfoWrapper.java
@@ -1,4 +1,4 @@
-package org.morib.server.global.sse;
+package org.morib.server.global.sse.api;
 
 public record UserInfoDtoForSseUserInfoWrapper(
         Long id,

--- a/morib/src/main/java/org/morib/server/global/sse/application/event/SseDisconnectEvent.java
+++ b/morib/src/main/java/org/morib/server/global/sse/application/event/SseDisconnectEvent.java
@@ -1,0 +1,16 @@
+package org.morib.server.global.sse.application.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class SseDisconnectEvent extends ApplicationEvent {
+
+    private final Long userId;
+
+    public SseDisconnectEvent(Object source, Long userId) {
+        super(source);
+        this.userId = userId;
+    }
+
+}

--- a/morib/src/main/java/org/morib/server/global/sse/application/event/SseTimeoutEvent.java
+++ b/morib/src/main/java/org/morib/server/global/sse/application/event/SseTimeoutEvent.java
@@ -1,0 +1,14 @@
+package org.morib.server.global.sse.application.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class SseTimeoutEvent extends ApplicationEvent {
+    private final Long userId;
+
+    public SseTimeoutEvent(Object source, Long userId) {
+        super(source);
+        this.userId = userId;
+    }
+}

--- a/morib/src/main/java/org/morib/server/global/sse/application/repository/SseUserInfoWrapper.java
+++ b/morib/src/main/java/org/morib/server/global/sse/application/repository/SseUserInfoWrapper.java
@@ -1,4 +1,4 @@
-package org.morib.server.global.sse;
+package org.morib.server.global.sse.application.repository;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/morib/src/main/java/org/morib/server/global/sse/application/service/SseSender.java
+++ b/morib/src/main/java/org/morib/server/global/sse/application/service/SseSender.java
@@ -1,0 +1,44 @@
+package org.morib.server.global.sse.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.morib.server.global.exception.SSEConnectionException;
+import org.morib.server.global.message.ErrorMessage;
+import org.morib.server.global.message.SseMessageBuilder;
+import org.morib.server.global.sse.application.event.SseDisconnectEvent;
+import org.morib.server.global.sse.application.event.SseTimeoutEvent;
+import org.morib.server.global.sse.application.repository.SseRepository;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.morib.server.global.common.Constants.SSE_EVENT_COMPLETION;
+
+@Component
+@RequiredArgsConstructor
+public class SseSender {
+
+    public void sendEvent(SseEmitter emitter, String eventName, Object data) {
+        try {
+            emitter.send(SseEmitter.event()
+                    .name(eventName)
+                    .data(data));
+        } catch (IOException e) {
+            throw new SSEConnectionException(ErrorMessage.SSE_CONNECT_FAILED);
+        }
+    }
+
+    public void broadcast(List<SseEmitter> emitters, String eventName, Object data) {
+        for (SseEmitter targetEmitter : emitters) {
+            try {
+                targetEmitter.send(SseEmitter.event()
+                        .name(eventName)
+                        .data(data));
+            } catch (IOException e) {
+                throw new SSEConnectionException(ErrorMessage.SSE_CONNECT_FAILED);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📍 Issue
- closes #113 

## ✨ Key Changes
- SSE 관련 클래스 아키텍처 리팩토링했습니다.
- SseController -> SseFacade -> SseService, SseSender -> SseRepository 형태의 아키텍처로 구성했습니다.
- SseRepository에서의 completion, timout 핸들러를 EventPublisher 형태로 이벤트를 발행한 뒤, Facade와 같은 계층의 EventHandler에서 핸들링하여 의존성이 역전되지 않도록 구성했습니다.
- Event Message 또한 요청 별로 구체화하여 업데이트 해두었습니다.
- 할일 추가 후 타이머 시작 api에서 Timer가 생성되는 로직이 빠져있어 추가했습니다.

## 💬 To Reviewers
