### PR TITLE
Feat [#119] 타이머 상단 허용 서비스 조회, 등록 API 구현

### DIFF
--- a/morib/src/main/java/org/morib/server/api/timerView/controller/TimerViewController.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/controller/TimerViewController.java
@@ -3,6 +3,7 @@ package org.morib.server.api.timerView.controller;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.morib.server.api.homeView.dto.StartTimerRequestDto;
+import org.morib.server.api.timerView.dto.AssignAllowedGroupsRequestDto;
 import org.morib.server.api.timerView.dto.RunTimerRequestDto;
 import org.morib.server.api.timerView.dto.StopTimerRequestDto;
 import org.morib.server.api.timerView.dto.TodoCardResponseDto;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v2")
 @RequiredArgsConstructor
 public class TimerViewController {
+
     private final TimerViewFacade timerViewFacade;
     private final PrincipalHandler principalHandler;
 
@@ -47,7 +49,6 @@ public class TimerViewController {
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 
-
     @GetMapping("/timer/todo-card")
     public ResponseEntity<BaseResponse<?>> getTodoCards(@AuthenticationPrincipal CustomUserDetails customUserDetails,
                                                         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate) {
@@ -63,5 +64,20 @@ public class TimerViewController {
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, timerViewFacade.fetchFriendsInfo(userId));
     }
 
+    // 허용 서비스 조회
+    @GetMapping("/timer/allowedGroups")
+    public ResponseEntity<BaseResponse<?>> getAllowedGroupsAndAllowedSites(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS, timerViewFacade.fetchAllowedGroupsInTimer(userId));
+    }
+
+    // 허용 서비스 등록
+    @PostMapping("/timer/allowedGroups")
+    public ResponseEntity<BaseResponse<?>> assignAllowedGroupsInTimer(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                                      @RequestBody AssignAllowedGroupsRequestDto assignAllowedGroupsRequestDto) {
+        Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
+        timerViewFacade.assignAllowedGroupsInTimer(userId, assignAllowedGroupsRequestDto);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS);
+    }
 
 }

--- a/morib/src/main/java/org/morib/server/api/timerView/dto/AssignAllowedGroupsRequestDto.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/dto/AssignAllowedGroupsRequestDto.java
@@ -1,0 +1,8 @@
+package org.morib.server.api.timerView.dto;
+
+import java.util.List;
+
+public record AssignAllowedGroupsRequestDto(
+        List<Long> allowedGroupIdList
+) {
+}

--- a/morib/src/main/java/org/morib/server/api/timerView/dto/FetchAllowedGroupInTimerResponseDto.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/dto/FetchAllowedGroupInTimerResponseDto.java
@@ -1,0 +1,20 @@
+package org.morib.server.api.timerView.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.morib.server.api.allowGroupView.dto.AllowedSiteWithIdVo;
+
+import java.util.List;
+
+public record FetchAllowedGroupInTimerResponseDto(
+        Long id,
+        String name,
+        String colorCode,
+        boolean selected,
+        @JsonProperty("allowedSites")
+        List<AllowedSiteWithIdVo> allowedSiteVos
+) {
+    public static FetchAllowedGroupInTimerResponseDto of(Long id, String name, String colorCode, boolean selected, List<AllowedSiteWithIdVo> allowedSiteWithIdVos){
+        return new FetchAllowedGroupInTimerResponseDto(id, name, colorCode, selected, allowedSiteWithIdVos);
+    }
+
+}

--- a/morib/src/main/java/org/morib/server/api/timerView/dto/TaskInTodoCardDto.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/dto/TaskInTodoCardDto.java
@@ -5,15 +5,17 @@ import org.morib.server.domain.task.infra.Task;
 import java.time.LocalDate;
 
 public record TaskInTodoCardDto(
+    Long id,
     String name,
+    String categoryName,
     LocalDate startDate,
     LocalDate endDate,
     boolean isComplete,
     LocalDate targetDate,
-    int targetTime
+    int elapsedTime
 ) {
 
     public static TaskInTodoCardDto of(Task task, LocalDate targetDate, int elapsedTime){
-        return new TaskInTodoCardDto(task.getName(), task.getStartDate(), task.getEndDate(), task.getIsComplete(), targetDate, elapsedTime);
+        return new TaskInTodoCardDto(task.getId(), task.getName(), task.getCategory().getName(), task.getStartDate(), task.getEndDate(), task.getIsComplete(), targetDate, elapsedTime);
     }
 }

--- a/morib/src/main/java/org/morib/server/domain/allowedGroup/infra/AllowedGroupManager.java
+++ b/morib/src/main/java/org/morib/server/domain/allowedGroup/infra/AllowedGroupManager.java
@@ -1,4 +1,4 @@
-package org.morib.server.domain.allowedGroup.application;
+package org.morib.server.domain.allowedGroup.infra;
 
 import org.morib.server.annotation.Manager;
 import org.morib.server.domain.allowedGroup.infra.AllowedGroup;

--- a/morib/src/main/java/org/morib/server/domain/recentAllowedGroup/application/CreateRecentAllowedGroupService.java
+++ b/morib/src/main/java/org/morib/server/domain/recentAllowedGroup/application/CreateRecentAllowedGroupService.java
@@ -1,0 +1,9 @@
+package org.morib.server.domain.recentAllowedGroup.application;
+
+import org.morib.server.domain.recentAllowedGroup.infra.RecentAllowedGroup;
+
+import java.util.List;
+
+public interface CreateRecentAllowedGroupService {
+    void create(List<RecentAllowedGroup> recentAllowedGroupList);
+}

--- a/morib/src/main/java/org/morib/server/domain/recentAllowedGroup/application/DeleteRecentAllowedGroupService.java
+++ b/morib/src/main/java/org/morib/server/domain/recentAllowedGroup/application/DeleteRecentAllowedGroupService.java
@@ -1,0 +1,12 @@
+package org.morib.server.domain.recentAllowedGroup.application;
+
+import org.morib.server.domain.recentAllowedGroup.infra.RecentAllowedGroup;
+
+import java.util.List;
+
+public interface DeleteRecentAllowedGroupService {
+    void deleteAll(Long userId);
+    void delete(List<RecentAllowedGroup> recentAllowedGroupList);
+    void deleteById(Long id);
+    void deleteByAllowedGroupId(Long allowedGroupId);
+}

--- a/morib/src/main/java/org/morib/server/domain/recentAllowedGroup/application/FetchRecentAllowedGroupService.java
+++ b/morib/src/main/java/org/morib/server/domain/recentAllowedGroup/application/FetchRecentAllowedGroupService.java
@@ -1,0 +1,9 @@
+package org.morib.server.domain.recentAllowedGroup.application;
+
+import org.morib.server.domain.recentAllowedGroup.infra.RecentAllowedGroup;
+
+import java.util.List;
+
+public interface FetchRecentAllowedGroupService {
+    List<RecentAllowedGroup> findAllByUserId(Long userId);
+}

--- a/morib/src/main/java/org/morib/server/domain/recentAllowedGroup/application/impl/CreateRecentAllowedGroupServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/recentAllowedGroup/application/impl/CreateRecentAllowedGroupServiceImpl.java
@@ -1,0 +1,23 @@
+package org.morib.server.domain.recentAllowedGroup.application.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.morib.server.domain.recentAllowedGroup.application.CreateRecentAllowedGroupService;
+import org.morib.server.domain.recentAllowedGroup.infra.RecentAllowedGroup;
+import org.morib.server.domain.recentAllowedGroup.infra.RecentAllowedGroupRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CreateRecentAllowedGroupServiceImpl implements CreateRecentAllowedGroupService {
+
+    private final RecentAllowedGroupRepository recentAllowedGroupRepository;
+
+    @Override
+    @Transactional
+    public void create(List<RecentAllowedGroup> recentAllowedGroupList) {
+        recentAllowedGroupRepository.saveAll(recentAllowedGroupList);
+    }
+}

--- a/morib/src/main/java/org/morib/server/domain/recentAllowedGroup/application/impl/DeleteRecentAllowedGroupServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/recentAllowedGroup/application/impl/DeleteRecentAllowedGroupServiceImpl.java
@@ -1,0 +1,41 @@
+package org.morib.server.domain.recentAllowedGroup.application.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.morib.server.domain.recentAllowedGroup.application.DeleteRecentAllowedGroupService;
+import org.morib.server.domain.recentAllowedGroup.infra.RecentAllowedGroup;
+import org.morib.server.domain.recentAllowedGroup.infra.RecentAllowedGroupRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteRecentAllowedGroupServiceImpl implements DeleteRecentAllowedGroupService {
+
+    private final RecentAllowedGroupRepository recentAllowedGroupRepository;
+
+    @Override
+    @Transactional
+    public void deleteAll(Long userId) {
+        recentAllowedGroupRepository.deleteAllByUserId(userId);
+    }
+
+    @Override
+    @Transactional
+    public void delete(List<RecentAllowedGroup> recentAllowedGroupList) {
+        recentAllowedGroupRepository.deleteAll(recentAllowedGroupList);
+    }
+
+    @Override
+    @Transactional
+    public void deleteById(Long id) {
+        recentAllowedGroupRepository.deleteById(id);
+    }
+
+    @Override
+    @Transactional
+    public void deleteByAllowedGroupId(Long allowedGroupId) {
+        recentAllowedGroupRepository.deleteBySelectedAllowedGroupId(allowedGroupId);
+    }
+}

--- a/morib/src/main/java/org/morib/server/domain/recentAllowedGroup/application/impl/FetchRecentAllowedGroupServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/recentAllowedGroup/application/impl/FetchRecentAllowedGroupServiceImpl.java
@@ -1,0 +1,21 @@
+package org.morib.server.domain.recentAllowedGroup.application.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.morib.server.domain.recentAllowedGroup.application.FetchRecentAllowedGroupService;
+import org.morib.server.domain.recentAllowedGroup.infra.RecentAllowedGroup;
+import org.morib.server.domain.recentAllowedGroup.infra.RecentAllowedGroupRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FetchRecentAllowedGroupServiceImpl implements FetchRecentAllowedGroupService {
+
+    private final RecentAllowedGroupRepository recentAllowedGroupRepository;
+
+    @Override
+    public List<RecentAllowedGroup> findAllByUserId(Long userId) {
+        return recentAllowedGroupRepository.findAllByUserId(userId);
+    }
+}

--- a/morib/src/main/java/org/morib/server/domain/recentAllowedGroup/infra/RecentAllowedGroup.java
+++ b/morib/src/main/java/org/morib/server/domain/recentAllowedGroup/infra/RecentAllowedGroup.java
@@ -1,0 +1,31 @@
+package org.morib.server.domain.recentAllowedGroup.infra;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.morib.server.domain.allowedGroup.infra.AllowedGroup;
+import org.morib.server.domain.user.infra.User;
+import org.morib.server.global.common.BaseTimeEntity;
+
+@Builder
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RecentAllowedGroup extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+    @OneToOne
+    @JoinColumn(name = "allowed_group_id")
+    private AllowedGroup selectedAllowedGroup;
+
+    public static RecentAllowedGroup create(User user, AllowedGroup allowedGroup) {
+        return RecentAllowedGroup.builder()
+                .user(user)
+                .selectedAllowedGroup(allowedGroup)
+                .build();
+    }
+}

--- a/morib/src/main/java/org/morib/server/domain/recentAllowedGroup/infra/RecentAllowedGroupRepository.java
+++ b/morib/src/main/java/org/morib/server/domain/recentAllowedGroup/infra/RecentAllowedGroupRepository.java
@@ -1,0 +1,11 @@
+package org.morib.server.domain.recentAllowedGroup.infra;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RecentAllowedGroupRepository extends JpaRepository<RecentAllowedGroup, Long> {
+    List<RecentAllowedGroup> findAllByUserId(Long userId);
+    void deleteAllByUserId(Long userId);
+    void deleteBySelectedAllowedGroupId(Long allowedGroupId);
+}


### PR DESCRIPTION
## 📍 Issue
- closes #119 

## ✨ Key Changes
타이머 상단 허용 서비스 조회, 등록 API 구현했습니다.
타이머 내에서 최근 선택한 허용 서비스를 아카이빙하기 위한 RecentAllowedGroup Entity 생성했습니다. AllowedGroup이 사라지면 같이 사라질 수 있도록 1:1 Cascade 설정했습니다.

## 💬 To Reviewers
