### PR TITLE
Refactor [#127] 할일 카드 조회 시 태스크 정렬을 위한 타입 마이그레이션

### DIFF
--- a/morib/src/main/java/org/morib/server/api/homeView/facade/HomeViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/homeView/facade/HomeViewFacade.java
@@ -105,7 +105,7 @@ public class HomeViewFacade {
                 .orElseGet(() -> createTodoService.saveTodoByUserAndTargetDate(findUser, targetDate));
 
         // Task ID 리스트 조회 (Batch 조회)
-        Set<Task> tasks = fetchTaskService.fetchByTaskIds(startTimerRequestDto.taskIdList());
+        List<Task> tasks = fetchTaskService.fetchByTaskIds(startTimerRequestDto.taskIdList());
 
         // 타이머가 존재하는 Task 조회 (Batch 조회)
         Set<Long> existingTimerTaskIds = fetchTimerService.fetchExistingTaskIdsByTargetDate(tasks, targetDate);
@@ -118,7 +118,7 @@ public class HomeViewFacade {
     }
 
     private void updateTaskInTodo(StartTimerRequestDto startTimerRequestDto, Todo todo) {
-        Set<Task> tasks = fetchTaskService.fetchByTaskIds(startTimerRequestDto.taskIdList());
+        List<Task> tasks = fetchTaskService.fetchByTaskIds(startTimerRequestDto.taskIdList());
         todoManager.updateTask(todo, tasks);
     }
 

--- a/morib/src/main/java/org/morib/server/api/timerView/dto/StopTimerRequestDto.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/dto/StopTimerRequestDto.java
@@ -5,7 +5,6 @@ import java.time.LocalDate;
 public record StopTimerRequestDto(
         LocalDate targetDate,
         int elapsedTime,
-        String runningCategoryName,
-        Long taskId
+        String runningCategoryName
 ) {
 }

--- a/morib/src/main/java/org/morib/server/domain/category/application/FetchCategoryService.java
+++ b/morib/src/main/java/org/morib/server/domain/category/application/FetchCategoryService.java
@@ -12,8 +12,8 @@ import org.morib.server.domain.user.infra.User;
 import java.util.Set;
 
 public interface FetchCategoryService {
-    List<Category> fetchByUserIdInRange(Long userId, LocalDate startDate, LocalDate endDate);
     Set<Category> fetchByUser(User user);
     CategoryWithTasks convertToCategoryWithTasks(Category category, LinkedHashSet<TaskWithTimers> taskWithTimers);
     Category fetchByUserAndCategoryId(User findUser, Long categoryId);
+    List<Category> fetchByUserIdWithFilteredTasksAndTimers(Long userId, LocalDate startDate, LocalDate endDate);
 }

--- a/morib/src/main/java/org/morib/server/domain/category/application/FetchCategoryServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/category/application/FetchCategoryServiceImpl.java
@@ -19,12 +19,8 @@ import java.util.Set;
 @RequiredArgsConstructor
 @Service
 public class FetchCategoryServiceImpl implements FetchCategoryService{
-    private final CategoryRepository categoryRepository;
 
-    @Override
-    public List<Category> fetchByUserIdInRange(Long userId, LocalDate startDate, LocalDate endDate) {
-        return categoryRepository.findByUserIdInRange(userId, startDate, endDate);
-    }
+    private final CategoryRepository categoryRepository;
 
     @Override
     public Set<Category> fetchByUser(User user) {
@@ -40,6 +36,11 @@ public class FetchCategoryServiceImpl implements FetchCategoryService{
     public Category fetchByUserAndCategoryId(User findUser, Long categoryId) {
         return categoryRepository.findByUserAndId(findUser, categoryId).
             orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+    }
+
+    @Override
+    public List<Category> fetchByUserIdWithFilteredTasksAndTimers(Long userId, LocalDate startDate, LocalDate endDate) {
+        return categoryRepository.findByUserIdWithFilteredTasksAndTimers(userId, startDate, endDate);
     }
 
 }

--- a/morib/src/main/java/org/morib/server/domain/task/application/FetchTaskService.java
+++ b/morib/src/main/java/org/morib/server/domain/task/application/FetchTaskService.java
@@ -12,7 +12,8 @@ import org.morib.server.domain.todo.infra.Todo;
 
 public interface FetchTaskService {
     Task fetchById(Long taskId);
+    Task fetchByIdAndTimer(Long taskId);
     LinkedHashSet<Task> fetchByTodoAndSameTargetDate(Todo todo, LocalDate targetDate);
     TaskWithTimers convertToTaskWithTimers(Task task);
-    Set<Task> fetchByTaskIds(List<Long> id);
+    List<Task> fetchByTaskIds(List<Long> id);
 }

--- a/morib/src/main/java/org/morib/server/domain/task/application/FetchTaskServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/task/application/FetchTaskServiceImpl.java
@@ -3,10 +3,7 @@ package org.morib.server.domain.task.application;
 import lombok.RequiredArgsConstructor;
 import org.morib.server.api.homeView.vo.TaskWithTimers;
 import java.time.LocalDate;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.morib.server.domain.category.infra.Category;
@@ -32,26 +29,27 @@ public class FetchTaskServiceImpl implements FetchTaskService {
     }
 
     @Override
+    public Task fetchByIdAndTimer(Long taskId) {
+        return taskRepository.findTaskWithTimers(taskId).orElseThrow(() ->
+                new NotFoundException(ErrorMessage.NOT_FOUND));
+    }
+
+    @Override
     public LinkedHashSet<Task> fetchByTodoAndSameTargetDate(Todo todo, LocalDate targetDate) {
-        Set<Task> tasks = todo.getTasks();
-        return tasks.stream().
+        return todo.getTasks().stream().
             filter(task -> isTimerInTaskPresentTargetDate(task, targetDate))
             .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     @Override
-    public Set<Task> fetchByTaskIds(List<Long> taskIds) {
-        Set<Task> tasks = new LinkedHashSet<>();
+    public List<Task> fetchByTaskIds(List<Long> taskIds) {
+        List<Task> tasks = new ArrayList<>();
         for (Long taskId : taskIds) {
             Task findTask = taskRepository.findById(taskId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
             tasks.add(findTask);
         }
-        return convertUnmmodifiableSet(tasks);
-    }
-
-    private Set<Task> convertUnmmodifiableSet(Set<Task> tasks) {
-        return Collections.unmodifiableSet(tasks);
+        return tasks;
     }
 
     private boolean isTimerInTaskPresentTargetDate(Task task, LocalDate targetDate) {

--- a/morib/src/main/java/org/morib/server/domain/task/infra/TaskRepository.java
+++ b/morib/src/main/java/org/morib/server/domain/task/infra/TaskRepository.java
@@ -1,6 +1,5 @@
 package org.morib.server.domain.task.infra;
 
-import org.morib.server.domain.category.infra.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -8,7 +7,9 @@ import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+
 @Repository
 public interface TaskRepository extends JpaRepository<Task, Long> {
-    Optional<Category> findCategoryById(Long taskId);
+    @Query("SELECT t FROM Task t LEFT JOIN FETCH t.timers WHERE t.id = :taskId")
+    Optional<Task> findTaskWithTimers(@Param("taskId") Long taskId);
 }

--- a/morib/src/main/java/org/morib/server/domain/timer/application/FetchTimerService.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/application/FetchTimerService.java
@@ -15,5 +15,5 @@ public interface FetchTimerService {
     int sumOneTaskElapsedTimeInTargetDate(Task t, LocalDate targetDate);
     List<Timer> fetchByUserAndTargetDate(User user, LocalDate targetDate);
     int sumElapsedTimeByUser(User user, LocalDate targetDate);
-    Set<Long> fetchExistingTaskIdsByTargetDate(Set<Task> tasks, LocalDate targetDate);
+    Set<Long> fetchExistingTaskIdsByTargetDate(List<Task> tasks, LocalDate targetDate);
 }

--- a/morib/src/main/java/org/morib/server/domain/timer/application/FetchTimerServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/application/FetchTimerServiceImpl.java
@@ -13,6 +13,7 @@ import org.morib.server.domain.user.infra.User;
 import org.morib.server.global.exception.NotFoundException;
 import org.morib.server.global.message.ErrorMessage;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -60,7 +61,7 @@ public class FetchTimerServiceImpl implements FetchTimerService{
     }
 
     @Override
-    public Set<Long> fetchExistingTaskIdsByTargetDate(Set<Task> tasks, LocalDate targetDate) {
+    public Set<Long> fetchExistingTaskIdsByTargetDate(List<Task> tasks, LocalDate targetDate) {
         List<Long> taskIds = tasks.stream()
                 .map(Task::getId)
                 .toList(); // Task ID 리스트 변환

--- a/morib/src/main/java/org/morib/server/domain/todo/TodoManager.java
+++ b/morib/src/main/java/org/morib/server/domain/todo/TodoManager.java
@@ -1,5 +1,6 @@
 package org.morib.server.domain.todo;
 
+import java.util.List;
 import java.util.Set;
 import org.morib.server.annotation.Manager;
 import org.morib.server.domain.task.infra.Task;
@@ -8,7 +9,7 @@ import org.morib.server.domain.todo.infra.Todo;
 @Manager
 public class TodoManager {
 
-    public void updateTask(Todo todo, Set<Task> tasks) {
+    public void updateTask(Todo todo, List<Task> tasks) {
         todo.updateTasks(tasks);
     }
 }

--- a/morib/src/main/java/org/morib/server/domain/todo/infra/Todo.java
+++ b/morib/src/main/java/org/morib/server/domain/todo/infra/Todo.java
@@ -10,7 +10,9 @@ import org.morib.server.domain.user.infra.User;
 import org.morib.server.global.common.BaseTimeEntity;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 @Entity
@@ -34,7 +36,8 @@ public class Todo extends BaseTimeEntity {
             joinColumns = @JoinColumn(name = "todo_id"),
             inverseJoinColumns = @JoinColumn(name = "task_id")
     )
-    private Set<Task> tasks = new LinkedHashSet<>();
+    @OrderColumn(name = "task_order")
+    private List<Task> tasks = new ArrayList<>();
 
     @Builder
     public Todo(LocalDate targetDate, User user) {
@@ -49,7 +52,7 @@ public class Todo extends BaseTimeEntity {
             .build();
     }
 
-    public void updateTasks(Set<Task> tasks) {
+    public void updateTasks(List<Task> tasks) {
         this.tasks = tasks;
     }
 

--- a/morib/src/main/java/org/morib/server/domain/user/infra/User.java
+++ b/morib/src/main/java/org/morib/server/domain/user/infra/User.java
@@ -4,9 +4,9 @@ import jakarta.persistence.*;
 import java.util.LinkedHashSet;
 import lombok.*;
 import org.morib.server.domain.allowedGroup.infra.AllowedGroup;
+import org.morib.server.domain.recentAllowedGroup.infra.RecentAllowedGroup;
 import org.morib.server.domain.category.infra.Category;
 import org.morib.server.domain.user.infra.type.InterestArea;
-import org.morib.server.domain.user.infra.type.InterestAreaConverter;
 import org.morib.server.domain.user.infra.type.Platform;
 import org.morib.server.domain.user.infra.type.Role;
 import org.morib.server.global.common.BaseTimeEntity;
@@ -38,6 +38,8 @@ public class User extends BaseTimeEntity {
     private Set<Category> categories;
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<AllowedGroup> allowedGroups = new LinkedHashSet<>();
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<RecentAllowedGroup> recentAllowedGroups = new LinkedHashSet<>();
     @Enumerated(EnumType.STRING)
     private Role role;
 


### PR DESCRIPTION
## 📍 Issue
- closes #127 

## ✨ Key Changes
[기존 할일 카드 조회 시, 해당하는 태스크들의 순서가 계속 바뀌는 이슈]
Todo가 Set<Task> 형태로 연관관계를 맺고 있었기 때문에, 타이머 진입 시에 클라이언트에서 전달했던 순서가 유지되지 않았어요.
- 이를 위해, `@OrderColumn`을 이용한 조인 테이블에 인덱스를 생성했고 타입을 List<Task>로 변경했습니다.
- 추가적으로 지연 로딩 이슈 해결을 위한 Fetch Join 쿼리 추가했습니다.
## 💬 To Reviewers
