### PR TITLE
Fix [#131] 홈뷰 전체조회 이슈 해결

### DIFF
--- a/morib/src/main/java/org/morib/server/api/homeView/facade/HomeViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/homeView/facade/HomeViewFacade.java
@@ -70,8 +70,8 @@ public class HomeViewFacade {
                         List<TaskInfo> taskInfos = category.getTasks().stream()
                                 .filter(task -> classifyTaskService.isTaskInDateRange(task, currentIdxDate))
                                 .map(task -> TaskInfo.of(task, fetchTimerService.fetchElapsedTimeOrZeroByTaskAndTargetDate(task, currentIdxDate)))
+                                .sorted(Comparator.comparing(TaskInfo::createdAt))
                                 .toList();
-
                         // Task가 없어도 Category는 표시해야 하므로 빈 리스트라도 포함
                         return CombinedCategoryAndTaskInfo.of(CategoryInfo.of(category), !taskInfos.isEmpty() ? taskInfos : Collections.emptyList());
                     }).toList();

--- a/morib/src/main/java/org/morib/server/api/homeView/facade/HomeViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/homeView/facade/HomeViewFacade.java
@@ -28,7 +28,6 @@ import org.morib.server.domain.todo.infra.Todo;
 import org.morib.server.domain.user.application.service.FetchUserService;
 import org.morib.server.domain.user.infra.User;
 import org.morib.server.global.common.DataUtils;
-import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -54,13 +53,12 @@ public class HomeViewFacade {
     private final TaskManager taskManager;
 
     public List<HomeViewResponseDto> fetchHome(Long userId, LocalDate startDate, LocalDate endDate) {
-        List<Category> findCategories = fetchCategoryService.fetchByUserIdWithFilteredTasksAndTimers(userId, startDate, endDate);
+        List<Category> findCategories = fetchCategoryService.fetchByUserIdAndTasksAndTimers(userId);
         return buildHomeViewResponseDto(startDate, endDate, findCategories);
     }
 
     private List<HomeViewResponseDto> buildHomeViewResponseDto(LocalDate startDate, LocalDate endDate, List<Category> findCategories) {
         List<HomeViewResponseDto> homeViewList = new ArrayList<>();
-
         // 날짜 범위별로 데이터를 분류
         for (LocalDate idxDate = startDate; !idxDate.isAfter(endDate); idxDate = idxDate.plusDays(1)) {
             LocalDate currentIdxDate = idxDate;

--- a/morib/src/main/java/org/morib/server/api/homeView/vo/TaskInfo.java
+++ b/morib/src/main/java/org/morib/server/api/homeView/vo/TaskInfo.java
@@ -3,6 +3,7 @@ package org.morib.server.api.homeView.vo;
 import org.morib.server.domain.task.infra.Task;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record TaskInfo(
         Long id,
@@ -10,8 +11,8 @@ public record TaskInfo(
         LocalDate startDate,
         LocalDate endDate,
         int elapsedTime,
-        boolean isComplete
-) {
+        boolean isComplete,
+        LocalDateTime createdAt) {
     public static TaskInfo of(Task task, int elapsedTime) {
         return new TaskInfo(
                 task.getId(),
@@ -19,7 +20,8 @@ public record TaskInfo(
                 task.getStartDate(),
                 task.getEndDate(),
                 elapsedTime,
-                task.getIsComplete());
+                task.getIsComplete(),
+                task.getCreatedAt());
     }
 }
 

--- a/morib/src/main/java/org/morib/server/api/timerView/dto/TodoCardResponseDto.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/dto/TodoCardResponseDto.java
@@ -2,5 +2,7 @@ package org.morib.server.api.timerView.dto;
 
 import java.util.List;
 
-public record TodoCardResponseDto(int totalTimeOfToday,List<TaskInTodoCardDto> task) {
+public record TodoCardResponseDto(
+        int totalTimeOfToday,
+        List<TaskInTodoCardDto> task) {
 }

--- a/morib/src/main/java/org/morib/server/domain/allowedSite/application/FetchSiteInfoServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/allowedSite/application/FetchSiteInfoServiceImpl.java
@@ -18,6 +18,7 @@ public class FetchSiteInfoServiceImpl implements FetchSiteInfoService {
     @Override
     public AllowedSiteVo fetch(String url) {
         try {
+
             Document doc = Jsoup.connect(url)
                     .userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
                             "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
@@ -43,8 +44,6 @@ public class FetchSiteInfoServiceImpl implements FetchSiteInfoService {
 
             Element faviconElement = doc.selectFirst("link[rel~=(?i)^(shortcut icon|icon|shortcut)$]");
             String favicon = (faviconElement != null) ? faviconElement.absUrl("href") : "";
-
-
 
             if (favicon.isEmpty()) {
                 favicon = url + "/favicon.ico"; // 기본 파비콘 경로

--- a/morib/src/main/java/org/morib/server/domain/category/application/FetchCategoryService.java
+++ b/morib/src/main/java/org/morib/server/domain/category/application/FetchCategoryService.java
@@ -15,5 +15,5 @@ public interface FetchCategoryService {
     Set<Category> fetchByUser(User user);
     CategoryWithTasks convertToCategoryWithTasks(Category category, LinkedHashSet<TaskWithTimers> taskWithTimers);
     Category fetchByUserAndCategoryId(User findUser, Long categoryId);
-    List<Category> fetchByUserIdWithFilteredTasksAndTimers(Long userId, LocalDate startDate, LocalDate endDate);
+    List<Category> fetchByUserIdAndTasksAndTimers(Long userId);
 }

--- a/morib/src/main/java/org/morib/server/domain/category/application/FetchCategoryServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/category/application/FetchCategoryServiceImpl.java
@@ -39,8 +39,8 @@ public class FetchCategoryServiceImpl implements FetchCategoryService{
     }
 
     @Override
-    public List<Category> fetchByUserIdWithFilteredTasksAndTimers(Long userId, LocalDate startDate, LocalDate endDate) {
-        return categoryRepository.findByUserIdWithFilteredTasksAndTimers(userId, startDate, endDate);
+    public List<Category> fetchByUserIdAndTasksAndTimers(Long userId) {
+        return categoryRepository.findByUserIdAndFetchTasksAndTimers(userId);
     }
 
 }

--- a/morib/src/main/java/org/morib/server/domain/category/infra/CategoryRepository.java
+++ b/morib/src/main/java/org/morib/server/domain/category/infra/CategoryRepository.java
@@ -4,23 +4,16 @@ import java.util.Optional;
 import org.morib.server.domain.user.infra.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDate;
 import java.util.List;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     Optional<Category> findByUserAndId(User findUser, Long categoryId);
 
-    @Query("SELECT DISTINCT c FROM Category c " +
+    @Query("SELECT c FROM Category c " +
             "LEFT JOIN FETCH c.tasks t " +
             "LEFT JOIN FETCH t.timers ti " +
             "WHERE c.user.id = :userId " +
-            "AND (t IS NULL OR " +
-            "(t.startDate BETWEEN :startDate AND :endDate " +
-            "OR (t.startDate <= :endDate AND t.endDate IS NULL) " +
-            "OR (t.startDate <= :endDate AND t.endDate >= :startDate))) " +
             "ORDER BY c.createdAt ASC ")
-    List<Category> findByUserIdWithFilteredTasksAndTimers(Long userId, LocalDate startDate, LocalDate endDate);
-
+    List<Category> findByUserIdAndFetchTasksAndTimers(Long userId);
 }

--- a/morib/src/main/java/org/morib/server/domain/todo/application/FetchTodoServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/todo/application/FetchTodoServiceImpl.java
@@ -22,8 +22,8 @@ public class FetchTodoServiceImpl implements FetchTodoService {
     }
 
     @Override
-    public Todo fetchByUserIdAndTargetDate(Long mockUserId, LocalDate targetDate) {
-        return todoRepository.findTodoByUserIdAndTargetDate(mockUserId, targetDate)
+    public Todo fetchByUserIdAndTargetDate(Long userId, LocalDate targetDate) {
+        return todoRepository.findTodoByUserIdAndTargetDate(userId, targetDate)
             .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
     }
 

--- a/morib/src/main/java/org/morib/server/domain/user/infra/type/InterestArea.java
+++ b/morib/src/main/java/org/morib/server/domain/user/infra/type/InterestArea.java
@@ -12,15 +12,7 @@ public enum InterestArea {
         new InterestAreaSiteVo("Salesforce", "https://www.salesforce.com/kr/?ir=1"),
         new InterestAreaSiteVo("Slack", "https://slack.com/intl/ko-kr/"),
         new InterestAreaSiteVo("Dropbox", "https://www.dropbox.com/business")
-    )
-        ),
-//    CREATOR("Creator", List.of(
-//        new InterestAreaSiteVo("브런치스토리", "https://brunch.co.kr/"),
-//        new InterestAreaSiteVo("위키피디아", "https://www.wikipedia.org/"),
-//        new InterestAreaSiteVo("ChatGPT", "https://openai.com/index/chatgpt/"),
-//        new InterestAreaSiteVo("한국어 맞춤법/문법 검사기", "https://nara-speller.co.kr/speller/"),
-//        new InterestAreaSiteVo("포스타입", "https://www.postype.com/")
-//    )),
+    )),
     DESIGNER("Designer", List.of(
         new InterestAreaSiteVo("피그마", "https://www.figma.com/"),
         new InterestAreaSiteVo("언스플레쉬", "https://unsplash.com/ko"),
@@ -58,13 +50,6 @@ public enum InterestArea {
         new InterestAreaSiteVo("Google Drive", "https://drive.google.com/"),
         new InterestAreaSiteVo("Google Workspace", "https://meet.google.com/")
     )),
-//    ENGINEER("Engineer", List.of(
-//        new InterestAreaSiteVo("Wolfram Alpha", "https://www.wolframalpha.com/"),
-//        new InterestAreaSiteVo("ChatGPT", "https://chatgpt.com/"),
-//        new InterestAreaSiteVo("iLovePDF", "https://www.ilovepdf.com/ko"),
-//        new InterestAreaSiteVo("반도체설계교육센터", "http://www.idec.or.kr/"),
-//        new InterestAreaSiteVo("Wcalc", "https://wcalc.sourceforge.net/")
-//    )),
     OTHERS("Others", List.of(
         new InterestAreaSiteVo("네이버 파파고", "https://papago.naver.com/"),
         new InterestAreaSiteVo("ChatGPT", "https://chatgpt.com/"),


### PR DESCRIPTION
## 📍 Issue
- closes #131 

## ✨ Key Changes
홈뷰 전체조회 시, 태스크의 날짜에 따라 카테고리가 보였다 안보였다 하는 이슈가 있었습니다.
category, task, timer를 fetch join 시에 task의 날짜 범위에 대해 조건을 걸어 쿼리를 썼기 때문에, task 조건이 해당하지 않으면 category까지 조회되지 않고 있었습니다.
이에 전부 fetch join은 하되 조건 쿼리는 빼고, 어플리케이션 로직으로 task를 필터링해 dto 빌드했습니다.

추가로, task가 홈뷰에서 생성 시점 오름차순으로 정렬되지 않고 있어 명시적으로 필드를 추가해 정렬시켰습니다.

## 💬 To Reviewers
