### PR TITLE
Refactor [#139] 허용 서비스 리스트 조회 로직 수정

### DIFF
--- a/morib/src/main/java/org/morib/server/api/allowGroupView/dto/FetchAllowedGroupListResponseDto.java
+++ b/morib/src/main/java/org/morib/server/api/allowGroupView/dto/FetchAllowedGroupListResponseDto.java
@@ -6,9 +6,9 @@ public record FetchAllowedGroupListResponseDto(
         Long id,
         String name,
         String colorCode,
-        List<String> allowedSites,
+        List<String> favicons,
         int extraCnt) {
-    public static FetchAllowedGroupListResponseDto of(Long id, String name, String colorCode, List<String> allowedSites, int extraCnt) {
-        return new FetchAllowedGroupListResponseDto(id, name, colorCode, allowedSites, extraCnt);
+    public static FetchAllowedGroupListResponseDto of(Long id, String name, String colorCode, List<String> favicons, int extraCnt) {
+        return new FetchAllowedGroupListResponseDto(id, name, colorCode, favicons, extraCnt);
     }
 }

--- a/morib/src/main/java/org/morib/server/api/allowGroupView/facade/AllowedGroupViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/allowGroupView/facade/AllowedGroupViewFacade.java
@@ -67,9 +67,10 @@ public class AllowedGroupViewFacade {
     }
 
     private List<String> getTop5FaviconInAllowedGroup(AllowedGroup allowedGroup) {
-        return allowedGroup.getAllowedSites().stream()
-                .limit(MAX_VISIBLE_ALLOWED_SERVICES)
+        return filteredAllowedSitesByDomain(allowedGroup).values().stream()
+                .flatMap(List::stream)
                 .map(AllowedSite::getFavicon)
+                .limit(MAX_VISIBLE_ALLOWED_SERVICES)
                 .toList();
     }
 
@@ -91,6 +92,15 @@ public class AllowedGroupViewFacade {
     }
 
     public List<AllowedSiteWithIdVo> filterByTopDomainAndGetAllowedSiteWithIdVo(AllowedGroup findAllowedGroup) {
+        TreeMap<String, List<AllowedSite>> filteredAllowedSites = filteredAllowedSitesByDomain(findAllowedGroup);
+
+        return filteredAllowedSites.values().stream()
+                .flatMap(List::stream)
+                .map(AllowedSiteWithIdVo::of)
+                .toList();
+    }
+
+    private TreeMap<String, List<AllowedSite>> filteredAllowedSitesByDomain(AllowedGroup findAllowedGroup) {
         TreeMap<String, List<AllowedSite>> filteredAllowedSites = new TreeMap<>();
         for (AllowedSite allowedSite : findAllowedGroup.getAllowedSites()) {
             String domainForKey = fetchSiteInfoService.getTopDomain(allowedSite.getSiteUrl());
@@ -101,11 +111,7 @@ public class AllowedGroupViewFacade {
 
         filteredAllowedSites.values().forEach(
                 list -> list.sort(Comparator.comparing(AllowedSite::getSiteUrl)));
-
-        return filteredAllowedSites.values().stream()
-                .flatMap(List::stream)
-                .map(AllowedSiteWithIdVo::of)
-                .toList();
+        return filteredAllowedSites;
     }
 
     @Transactional


### PR DESCRIPTION
## 📍 Issue
- closes #139 

## ✨ Key Changes
- QA Notion Link : https://www.notion.so/1a997d212fa280e9aabdc8e3004c8224?pvs=4
- 허용 서비스 조회 시 컬러 팔레트 바꿀때마다 좌측 파비콘 정렬 바뀜 이슈를 해결했습니다.
- 정렬 로직이 명시되어있지 않아 AllowedGroup 상새조회 정렬 로직 extract 후 재사용해 수정했습니다.
- 중복 제거는 최상위 도메인을 추출하여 비교하기 때문에 아이콘이 다른데도 제거해버릴 수 있어서 2차 QA 후 이슈 있으면 수정하겠습니다.

## 💬 To Reviewers
