### PR TITLE
Refactor [#147] Response에 UTF-8 인코딩 적용 - QA 반영

### DIFF
--- a/morib/src/main/java/org/morib/server/global/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/morib/src/main/java/org/morib/server/global/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -16,7 +16,9 @@ public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
         response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.setContentType("text/html; charset=UTF-8");
+        response.setCharacterEncoding("UTF-8");
         response.getWriter().write("소셜 로그인 실패! 서버 로그를 확인해주세요.");
-        log.info("소셜 로그인에 실패했습니다. 에러 메시지 : {}", exception.getMessage());
+        log.error("소셜 로그인에 실패했습니다. 에러 메시지 : {}", exception.getMessage());
     }
 }


### PR DESCRIPTION
## 📍 Issue
- closes #147 

## ✨ Key Changes
- response.getWriter로 바로 화면에 텍스트를 표시했는데, 인코딩이 빠져 물음표로 보이는 문제가 있었습니다.

https://github.com/morib-in/Morib-Server-v2/blob/b298359c3541aa8a2134d89dc10dcd5e20114a3f/morib/src/main/java/org/morib/server/global/oauth2/handler/OAuth2LoginFailureHandler.java#L18-L22

실패 시 실행되는 OAuth2LoginFailureHandler의 Response에 UTF 인코딩을 적용해 해결했습니다.

## 💬 To Reviewers
