### PR TITLE
Fix [#153] SSE 구현 개선 및 메모리 누수 해결

### DIFF
--- a/morib/Dockerfile
+++ b/morib/Dockerfile
@@ -2,4 +2,4 @@
 FROM eclipse-temurin:17
 WORKDIR /app
 COPY ./build/libs/server-0.0.1-SNAPSHOT.jar /app/morib.jar
-CMD ["java", "-Duser.timezone=Asia/Seoul", "-jar", "morib.jar"]
+CMD ["java", "-Xms512m", "-Xmx1024m", "-XX:+UseG1GC", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/app/heapdump.hprof", "-Duser.timezone=Asia/Seoul", "-jar", "morib.jar"]

--- a/morib/src/main/java/org/morib/server/global/common/Constants.java
+++ b/morib/src/main/java/org/morib/server/global/common/Constants.java
@@ -13,6 +13,8 @@ public final class Constants {
     public static final String SEND = "send";
     public static final String RECEIVE = "receive";
     public static final Long SSE_TIMEOUT = 300_000L;
+    public static final Long MAX_CONNECTION_TIME = 30 * 60 * 1000L;
+    public static final int MAX_FAILED_ATTEMPTS = 100;
     public static final String IS_SIGN_UP_QUERYSTRING = "?isSignUp=";
     public static final String GOOGLE_REGISTRATION_ID = "google";
     public static final String INVALID_REFRESH_TOKEN = "invalid";

--- a/morib/src/main/java/org/morib/server/global/config/SecurityConfig.java
+++ b/morib/src/main/java/org/morib/server/global/config/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests((auth) -> auth
                 .requestMatchers("/","/css/**","/images/**","/js/**","/favicon.ico","/**").permitAll()
+                .requestMatchers("/api/v2/admin/sse/monitor", "/api/v2/admin/sse/gc").permitAll()
                 .anyRequest().authenticated()
         );
         http.addFilterAfter(jwtAuthenticationFilter(), LogoutFilter.class);

--- a/morib/src/main/java/org/morib/server/global/sse/api/SseController.java
+++ b/morib/src/main/java/org/morib/server/global/sse/api/SseController.java
@@ -20,9 +20,19 @@ public class SseController {
     private final SseFacade sseFacade;
 
     @GetMapping(value = "/sse/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public ResponseEntity<SseEmitter> connect(@AuthenticationPrincipal CustomUserDetails customUserDetails){
+    public ResponseEntity<SseEmitter> connect(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        // 연결 전 메모리 사용량 측정
+        long beforeMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+        log.info("SSE 연결 전 메모리 사용량: {} bytes", beforeMemory);
+
         Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
         SseEmitter emitter = sseFacade.init(userId);
+
+        // 연결 후 메모리 사용량 측정
+        long afterMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+        log.info("SSE 연결 후 메모리 사용량: {} bytes", afterMemory);
+        log.info("SSE 연결 당 메모리 사용량: {} bytes", afterMemory - beforeMemory);
+
         return ResponseEntity.ok(emitter);
     }
 

--- a/morib/src/main/java/org/morib/server/global/sse/api/SseController.java
+++ b/morib/src/main/java/org/morib/server/global/sse/api/SseController.java
@@ -41,12 +41,22 @@ public class SseController {
                                               @RequestHeader(required = false) String elapsedTime,
                                               @RequestHeader(required = false) String runningCategoryName,
                                               @RequestHeader(required = false) String taskId){
+        // 재연결 전 메모리 사용량 측정
+        long beforeMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+        log.info("SSE 재연결 전 메모리 사용량: {} bytes", beforeMemory);
+
         Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
         SseEmitter emitter = sseFacade.refresh(userId, UserInfoDtoForSseUserInfoWrapper.of(
                 userId,
                 elapsedTime == null ? 0 : Integer.parseInt(elapsedTime),
                 runningCategoryName == null ? "" : runningCategoryName,
                 taskId == null ? null : Long.parseLong(taskId)));
+
+        // 재연결 후 메모리 사용량 측정
+        long afterMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+        log.info("SSE 재연결 후 메모리 사용량: {} bytes", afterMemory);
+        log.info("SSE 재연결 당 메모리 사용량: {} bytes", afterMemory - beforeMemory);
+
         return ResponseEntity.ok(emitter);
     }
 

--- a/morib/src/main/java/org/morib/server/global/sse/api/SseFacade.java
+++ b/morib/src/main/java/org/morib/server/global/sse/api/SseFacade.java
@@ -39,8 +39,6 @@ public class SseFacade {
 
     public SseEmitter init(Long userId) {
         try {
-            SseEmitter existingEmitter = sseService.fetchSseEmitterByUserId(userId);
-            if (existingEmitter != null) existingEmitter.complete();
             SseEmitter createdEmitter = sseService.create();
             sseService.add(userId, createdEmitter);
             return broadcastAllAfterCreated(userId, createdEmitter, SSE_EVENT_CONNECT);

--- a/morib/src/main/java/org/morib/server/global/sse/api/SseFacade.java
+++ b/morib/src/main/java/org/morib/server/global/sse/api/SseFacade.java
@@ -1,17 +1,18 @@
 package org.morib.server.global.sse.api;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.morib.server.annotation.Facade;
 import org.morib.server.api.homeView.facade.HomeViewFacade;
 import org.morib.server.domain.relationship.application.FetchRelationshipService;
-import org.morib.server.domain.relationship.infra.Relationship;
 import org.morib.server.domain.task.application.FetchTaskService;
 import org.morib.server.domain.task.infra.Task;
 import org.morib.server.domain.timer.TimerManager;
 import org.morib.server.domain.timer.application.FetchTimerService;
 import org.morib.server.domain.timer.infra.Timer;
+import org.morib.server.global.exception.SSEConnectionException;
+import org.morib.server.global.message.ErrorMessage;
 import org.morib.server.global.message.SseMessageBuilder;
-import org.morib.server.global.sse.application.repository.SseRepository;
 import org.morib.server.global.sse.application.service.SseSender;
 import org.morib.server.global.sse.application.service.SseService;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -24,6 +25,7 @@ import static org.morib.server.global.common.Constants.SSE_EVENT_REFRESH;
 
 @Facade
 @RequiredArgsConstructor
+@Slf4j
 public class SseFacade {
 
     private final SseService sseService;

--- a/morib/src/main/java/org/morib/server/global/sse/application/repository/SseRepository.java
+++ b/morib/src/main/java/org/morib/server/global/sse/application/repository/SseRepository.java
@@ -2,7 +2,10 @@ package org.morib.server.global.sse.application.repository;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,8 +24,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import static org.morib.server.global.common.Constants.SSE_EVENT_COMPLETION;
-import static org.morib.server.global.common.Constants.SSE_TIMEOUT;
+import static org.morib.server.global.common.Constants.*;
 
 @Repository
 @Slf4j

--- a/morib/src/main/java/org/morib/server/global/sse/application/service/SseSender.java
+++ b/morib/src/main/java/org/morib/server/global/sse/application/service/SseSender.java
@@ -85,3 +85,16 @@ public class SseSender {
             }
         }
     }
+
+    @Scheduled(fixedRate = 300000) // 5분마다 실행
+    public void checkFailedAttempts() {
+        int currentFailures = failedSendAttempts.get();
+        if (currentFailures > 0) {
+            log.info("현재 SSE 이벤트 전송 실패 횟수: {}", currentFailures);
+        }
+        
+        // 실패 카운터 재설정
+        failedSendAttempts.set(0);
+    }
+}
+

--- a/morib/src/main/java/org/morib/server/global/sse/application/service/SseSender.java
+++ b/morib/src/main/java/org/morib/server/global/sse/application/service/SseSender.java
@@ -1,12 +1,14 @@
 package org.morib.server.global.sse.application.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.morib.server.global.exception.SSEConnectionException;
 import org.morib.server.global.message.ErrorMessage;
 import org.morib.server.global.message.SseMessageBuilder;
 import org.morib.server.global.sse.application.event.SseDisconnectEvent;
 import org.morib.server.global.sse.application.event.SseTimeoutEvent;
 import org.morib.server.global.sse.application.repository.SseRepository;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -14,27 +16,59 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.morib.server.global.common.Constants.MAX_FAILED_ATTEMPTS;
 import static org.morib.server.global.common.Constants.SSE_EVENT_COMPLETION;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class SseSender {
 
+    // 실패한 전송 시도 횟수를 추적하기 위한 카운터
+    private final AtomicInteger failedSendAttempts = new AtomicInteger(0);
+    
     public void sendEvent(SseEmitter emitter, String eventName, Object data) {
+        if (emitter == null) {
+            log.warn("SseEmitter가 null입니다. 이벤트 전송을 건너뜁니다: {}", eventName);
+            return;
+        }
+        
         try {
-            if (emitter != null) {
-                emitter.send(SseEmitter.event()
-                        .name(eventName)
-                        .data(data));
+            emitter.send(SseEmitter.event()
+                    .name(eventName)
+                    .data(data));
+            
+            // 성공적인 전송 후 실패 카운터 재설정
+            if (failedSendAttempts.get() > 0) {
+                failedSendAttempts.set(0);
             }
         } catch (IOException e) {
+            // 실패 카운터 증가
+            int currentFailures = failedSendAttempts.incrementAndGet();
+            
+            // 최대 실패 횟수 초과 시 경고 로그
+            if (currentFailures > MAX_FAILED_ATTEMPTS) {
+                log.warn("SSE 이벤트 전송 실패 횟수가 임계값을 초과했습니다: {}", currentFailures);
+            }
+            
+            log.error("SSE 이벤트 전송 실패: {}", e.getMessage());
             emitter.completeWithError(e);
-            throw new SSEConnectionException(ErrorMessage.SSE_CONNECT_FAILED);
+        } catch (Exception e) {
+            log.error("SSE 이벤트 전송 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
+            emitter.completeWithError(e);
         }
     }
 
     public void broadcast(List<SseEmitter> emitters, String eventName, Object data) {
+        if (emitters == null || emitters.isEmpty()) {
+            log.debug("브로드캐스트할 SseEmitter가 없습니다: {}", eventName);
+            return;
+        }
+        
+        log.debug("이벤트 브로드캐스트: {}, 대상 수: {}", eventName, emitters.size());
+        
         for (SseEmitter targetEmitter : emitters) {
             try {
                 if (targetEmitter != null) {
@@ -43,9 +77,11 @@ public class SseSender {
                             .data(data));
                 }
             } catch (IOException e) {
+                log.error("SSE 브로드캐스트 실패: {}", e.getMessage());
                 targetEmitter.completeWithError(e);
-                throw new SSEConnectionException(ErrorMessage.SSE_CONNECT_FAILED);
+            } catch (Exception e) {
+                log.error("SSE 브로드캐스트 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
+                targetEmitter.completeWithError(e);
             }
         }
     }
-}


### PR DESCRIPTION
## 📍 Issue
- closes #153 

<br>

## ✨ Key Changes
SseEmitter 관련 메모리 누수 문제를 해결하기 위한 여러 개선 사항을 적용했어요.

### 1. 기존 연결 제거 로직 강화
- 동일한 사용자의 새 연결 요청 시 기존 연결을 명시적으로 제거하는 로직을 추가했습니다.

https://github.com/morib-in/Morib-Server-v2/blob/00a8ebcb0d8a378a03b6e2d611da6d18c9100b28/morib/src/main/java/org/morib/server/global/sse/application/repository/SseRepository.java#L142-L155

### 2. SseEmitter 콜백 개선
- SseEmitter에 등록하는 콜백을 개선하여 모든 상황에서 리소스를 정리하도록 했습니다.
- onError 콜백을 추가하여 예외 상황에서도 리소스를 정리합니다.

https://github.com/morib-in/Morib-Server-v2/blob/00a8ebcb0d8a378a03b6e2d611da6d18c9100b28/morib/src/main/java/org/morib/server/global/sse/application/repository/SseRepository.java#L50-L69

### 3. 오래된 연결 정리 메커니즘 추가
- 주기적으로 오래된 연결을 정리하는 스케줄러를 추가했습니다.
- 연결 시간이 MAX_CONNECTION_TIME을 초과하면 제거합니다.

https://github.com/morib-in/Morib-Server-v2/blob/00a8ebcb0d8a378a03b6e2d611da6d18c9100b28/morib/src/main/java/org/morib/server/global/sse/application/repository/SseRepository.java#L79-L109

### 4. SseSender에 atomicInteger 설정 및 에러 핸들링 추가
- atomicInteger를 사용하여 동시에  공유 변수에 접근하고 수정할 때도 안전하게 실패 횟수를 연산하도록 했습니다.
- 에러 발생 시에 실패한 sse 객체를 명시적으로 삭제하는 로직을 추가했습니다.

https://github.com/morib-in/Morib-Server-v2/blob/00a8ebcb0d8a378a03b6e2d611da6d18c9100b28/morib/src/main/java/org/morib/server/global/sse/application/service/SseSender.java#L30-L62

<br>

## 💡 Test Result
같은 사용자로 3번의 연결 요청을 보내 테스트했습니다.
```
2025-03-16 01:22:57.598 DEBUG o.s.security.web.FilterChainProxy Securing GET /api/v2/sse/connect
2025-03-16 01:22:57.673 DEBUG o.s.security.web.FilterChainProxy Secured GET /api/v2/sse/connect
2025-03-16 01:22:57.682 INFO  o.m.s.global.sse.api.SseController SSE 연결 전 메모리 사용량: 94475360 bytes
2025-03-16 01:22:57.684 INFO  o.m.s.g.s.a.repository.SseRepository 새 emitter 추가됨: SseEmitter@550c16d8
2025-03-16 01:22:57.684 INFO  o.m.s.g.s.a.repository.SseRepository emitter 목록 크기: 1
2025-03-16 01:22:57.722 INFO  o.m.s.global.sse.api.SseController SSE 연결 후 메모리 사용량: 97982080 bytes
2025-03-16 01:22:57.723 INFO  o.m.s.global.sse.api.SseController SSE 연결 당 메모리 사용량: 3506720 bytes
2025-03-16 01:23:25.368 DEBUG o.s.security.web.FilterChainProxy Securing GET /api/v2/sse/connect
2025-03-16 01:23:25.404 DEBUG o.s.security.web.FilterChainProxy Secured GET /api/v2/sse/connect
2025-03-16 01:23:25.405 INFO  o.m.s.global.sse.api.SseController SSE 연결 전 메모리 사용량: 99575608 bytes
2025-03-16 01:23:25.416 INFO  o.m.s.g.s.a.repository.SseRepository 새 emitter 추가됨: SseEmitter@35a4f74e
2025-03-16 01:23:25.416 INFO  o.m.s.g.s.a.repository.SseRepository emitter 목록 크기: 1
2025-03-16 01:23:25.421 DEBUG o.s.security.web.FilterChainProxy Securing GET /api/v2/sse/connect
2025-03-16 01:23:25.422 DEBUG o.s.security.web.FilterChainProxy Secured GET /api/v2/sse/connect
2025-03-16 01:23:25.427 INFO  o.m.s.global.sse.api.SseController SSE 연결 후 메모리 사용량: 100116416 bytes
2025-03-16 01:23:25.427 INFO  o.m.s.global.sse.api.SseController SSE 연결 당 메모리 사용량: 540808 bytes
2025-03-16 01:23:25.427 DEBUG o.s.s.w.a.AnonymousAuthenticationFilter Set SecurityContextHolder to anonymous SecurityContext
2025-03-16 01:23:25.428 INFO  o.m.s.g.s.a.repository.SseRepository onCompletion 콜백 - userId: 1
2025-03-16 01:23:25.429 INFO  o.m.s.global.sse.api.SseEventHandler SseDisconnectEvent received for userId: 1
2025-03-16 01:24:19.818 DEBUG o.s.security.web.FilterChainProxy Securing GET /api/v2/sse/connect
2025-03-16 01:24:19.892 DEBUG o.s.security.web.FilterChainProxy Secured GET /api/v2/sse/connect
2025-03-16 01:24:19.893 INFO  o.m.s.global.sse.api.SseController SSE 연결 전 메모리 사용량: 59168536 bytes
2025-03-16 01:24:19.894 INFO  o.m.s.g.s.a.repository.SseRepository 새 emitter 추가됨: SseEmitter@2b7a7994
2025-03-16 01:24:19.894 INFO  o.m.s.g.s.a.repository.SseRepository emitter 목록 크기: 1
2025-03-16 01:24:19.899 INFO  o.m.s.global.sse.api.SseController SSE 연결 후 메모리 사용량: 59396760 bytes
2025-03-16 01:24:19.899 INFO  o.m.s.global.sse.api.SseController SSE 연결 당 메모리 사용량: 228224 bytes

```


1. 연결당 메모리 사용량이 감소했습니다.
   - 첫 번째 연결: 약 3.3MB
   - 두 번째 연결: 약 0.5MB
   - 세 번째 연결: 약 0.2MB

2. 동일한 사용자의 중복 연결 방지가 정상적으로 작동합니다.
   - 새 연결 시 기존 연결이 정상적으로 종료됨
   - `emitter 목록 크기: 1`로 유지됨

3. 메모리 관리를 개선했습니다.
   - 가비지 컬렉션이 효과적으로 작동함
   - 메모리 사용량이 적절하게 관리됨


## 💬 To Reviewers
