### PR TITLE
Feat [#155] SSE 어드민 api 추가 및 모니터링 로깅 추가

### DIFF
--- a/morib/src/main/java/org/morib/server/MoribApplication.java
+++ b/morib/src/main/java/org/morib/server/MoribApplication.java
@@ -4,9 +4,11 @@ import org.morib.server.global.common.SecretProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableConfigurationProperties(SecretProperties.class)
+@EnableScheduling
 public class MoribApplication {
 
     public static void main(String[] args) {

--- a/morib/src/main/java/org/morib/server/domain/user/application/service/ReissueTokenServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/user/application/service/ReissueTokenServiceImpl.java
@@ -16,7 +16,7 @@ public class ReissueTokenServiceImpl implements ReissueTokenService{
     private final UserRepository userRepository;
 
     public ReissueTokenServiceDto reissue(String refreshToken) {
-        jwtService.isTokenValid(refreshToken);
+
         User findUser = userRepository.findByRefreshToken(refreshToken).orElseThrow(
                 () -> new NotFoundException(ErrorMessage.NOT_FOUND)
         );

--- a/morib/src/main/java/org/morib/server/global/sse/api/SseController.java
+++ b/morib/src/main/java/org/morib/server/global/sse/api/SseController.java
@@ -20,19 +20,9 @@ public class SseController {
     private final SseFacade sseFacade;
 
     @GetMapping(value = "/sse/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public ResponseEntity<SseEmitter> connect(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        // 연결 전 메모리 사용량 측정
-        long beforeMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
-        log.info("SSE 연결 전 메모리 사용량: {} bytes", beforeMemory);
-
+    public ResponseEntity<SseEmitter> connect(@AuthenticationPrincipal CustomUserDetails customUserDetails){
         Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
         SseEmitter emitter = sseFacade.init(userId);
-
-        // 연결 후 메모리 사용량 측정
-        long afterMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
-        log.info("SSE 연결 후 메모리 사용량: {} bytes", afterMemory);
-        log.info("SSE 연결 당 메모리 사용량: {} bytes", afterMemory - beforeMemory);
-
         return ResponseEntity.ok(emitter);
     }
 
@@ -41,22 +31,12 @@ public class SseController {
                                               @RequestHeader(required = false) String elapsedTime,
                                               @RequestHeader(required = false) String runningCategoryName,
                                               @RequestHeader(required = false) String taskId){
-        // 재연결 전 메모리 사용량 측정
-        long beforeMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
-        log.info("SSE 재연결 전 메모리 사용량: {} bytes", beforeMemory);
-
         Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
         SseEmitter emitter = sseFacade.refresh(userId, UserInfoDtoForSseUserInfoWrapper.of(
                 userId,
                 elapsedTime == null ? 0 : Integer.parseInt(elapsedTime),
                 runningCategoryName == null ? "" : runningCategoryName,
                 taskId == null ? null : Long.parseLong(taskId)));
-
-        // 재연결 후 메모리 사용량 측정
-        long afterMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
-        log.info("SSE 재연결 후 메모리 사용량: {} bytes", afterMemory);
-        log.info("SSE 재연결 당 메모리 사용량: {} bytes", afterMemory - beforeMemory);
-
         return ResponseEntity.ok(emitter);
     }
 

--- a/morib/src/main/java/org/morib/server/global/sse/api/SseMonitorController.java
+++ b/morib/src/main/java/org/morib/server/global/sse/api/SseMonitorController.java
@@ -1,0 +1,70 @@
+package org.morib.server.global.sse.api;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.morib.server.global.sse.application.repository.SseMemoryMonitor;
+import org.morib.server.global.sse.application.repository.SseRepository;
+import org.morib.server.global.sse.application.service.SseService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/v2/admin")
+public class SseMonitorController {
+
+    private final SseService sseService;
+
+    @GetMapping("/sse/monitor")
+    public ResponseEntity<Map<String, Object>> getMemoryUsage() {
+        Runtime runtime = Runtime.getRuntime();
+        long totalMemory = runtime.totalMemory();
+        long freeMemory = runtime.freeMemory();
+        long usedMemory = totalMemory - freeMemory;
+        int connectionCount = sseService.getConnectionCount();
+        
+        Map<String, Object> result = new HashMap<>();
+        result.put("totalMemoryMB", totalMemory / (1024 * 1024));
+        result.put("freeMemoryMB", freeMemory / (1024 * 1024));
+        result.put("usedMemoryMB", usedMemory / (1024 * 1024));
+        result.put("sseConnectionCount", connectionCount);
+        
+        if (connectionCount > 0) {
+            result.put("memoryPerConnectionKB", (usedMemory / connectionCount) / 1024);
+        } else {
+            result.put("memoryPerConnectionKB", 0);
+        }
+        // 연결된 사용자 ID 목록
+        result.put("connectedUserIds", sseService.getConnectedUserIds());
+
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/sse/gc")
+    public ResponseEntity<Map<String, Object>> forceGarbageCollection() {
+        Runtime runtime = Runtime.getRuntime();
+        
+        // 가비지 컬렉션 전 메모리 사용량
+        long beforeGcMemory = runtime.totalMemory() - runtime.freeMemory();
+        
+        // 가비지 컬렉션 실행
+        System.gc();
+        
+        // 가비지 컬렉션 후 메모리 사용량
+        long afterGcMemory = runtime.totalMemory() - runtime.freeMemory();
+        
+        Map<String, Object> result = new HashMap<>();
+        result.put("beforeGcMemoryMB", beforeGcMemory / (1024 * 1024));
+        result.put("afterGcMemoryMB", afterGcMemory / (1024 * 1024));
+        result.put("freedMemoryMB", (beforeGcMemory - afterGcMemory) / (1024 * 1024));
+        result.put("sseConnectionCount", sseService.getConnectionCount());
+        
+        return ResponseEntity.ok(result);
+    }
+} 

--- a/morib/src/main/java/org/morib/server/global/sse/application/repository/SseMemoryMonitor.java
+++ b/morib/src/main/java/org/morib/server/global/sse/application/repository/SseMemoryMonitor.java
@@ -1,0 +1,44 @@
+package org.morib.server.global.sse.application.repository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * SSE 연결의 메모리 사용량을 모니터링하는 클래스
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class SseMemoryMonitor {
+
+    private final SseRepository sseRepository;
+
+    @Scheduled(fixedRate = 60000) // 1분마다 실행
+    public void logMemoryUsage() {
+        Runtime runtime = Runtime.getRuntime();
+        
+        // 가비지 컬렉션 실행
+        System.gc();
+        
+        long usedMemory = runtime.totalMemory() - runtime.freeMemory();
+        int connectionCount = sseRepository.getConnectionCount();
+        
+        log.info("===== SSE Memory Monitor =====");
+        log.info("Total memory: {} MB", runtime.totalMemory() / (1024 * 1024));
+        log.info("Free memory: {} MB", runtime.freeMemory() / (1024 * 1024));
+        log.info("Used memory: {} MB", usedMemory / (1024 * 1024));
+        log.info("SSE connection count: {}", connectionCount);
+        
+        if (connectionCount > 0) {
+            log.info("Estimated memory per connection: {} KB", (usedMemory / connectionCount) / 1024);
+        }
+        
+        // 각 연결의 세부 정보 로깅
+        SseRepository.emitters.forEach((userId, wrapper) -> {
+            log.debug("Connection ID: {}, Category: {}, ElapsedTime: {}", 
+                    userId, wrapper.getRunningCategoryName(), wrapper.getElapsedTime());
+        });
+    }
+} 

--- a/morib/src/main/java/org/morib/server/global/sse/application/repository/SseRepository.java
+++ b/morib/src/main/java/org/morib/server/global/sse/application/repository/SseRepository.java
@@ -1,30 +1,22 @@
 package org.morib.server.global.sse.application.repository;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.morib.server.domain.relationship.application.FetchRelationshipService;
-import org.morib.server.domain.relationship.infra.Relationship;
-import org.morib.server.global.exception.SSEConnectionException;
-import org.morib.server.global.message.ErrorMessage;
 import org.morib.server.global.sse.application.event.SseDisconnectEvent;
 import org.morib.server.global.sse.application.event.SseHeartbeatEvent;
 import org.morib.server.global.sse.application.event.SseTimeoutEvent;
-import org.morib.server.global.userauth.CustomUserDetails;
-import org.morib.server.global.userauth.PrincipalHandler;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import static org.morib.server.global.common.Constants.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.morib.server.global.common.Constants.SSE_TIMEOUT;
 
 @Repository
 @Slf4j
@@ -139,33 +131,11 @@ public class SseRepository {
                 .toList();
     }
 
-    public boolean remove(Long userId) {
-        if (emitters.containsKey(userId)) {
-            SseEmitter emitter = emitters.get(userId).getSseEmitter();
-            if (emitter != null) {
-                try {
-                    emitter.complete();
-                } catch (Exception e) {
-                    log.warn("SseEmitter 완료 처리 중 오류 발생: {}", e.getMessage());
-                }
-            }
-            emitters.remove(userId);
-            return true;
-        }
-        return false;
+    public int getConnectionCount() {
+        return emitters.size();
     }
 
-    private void removeExistingEmitter(Long userId) {
-        if (emitters.containsKey(userId)) {
-            SseEmitter oldEmitter = emitters.get(userId).getSseEmitter();
-            if (oldEmitter != null) {
-                try {
-                    oldEmitter.complete();
-                } catch (Exception e) {
-                    log.warn("기존 SseEmitter 완료 처리 중 오류 발생: {}", e.getMessage());
-                }
-            }
-            emitters.remove(userId);
-        }
+    public Set<Long> getConnectedUserIds() {
+        return emitters.keySet();
     }
 }

--- a/morib/src/main/java/org/morib/server/global/sse/application/repository/SseRepository.java
+++ b/morib/src/main/java/org/morib/server/global/sse/application/repository/SseRepository.java
@@ -46,32 +46,31 @@ public class SseRepository {
         log.info("emitter 목록 크기: {}", emitters.size());
         
         if (emitter != null) {
-
             emitter.onCompletion(() -> {
                 log.info("onCompletion 콜백 - userId: {}", userId);
-                emitters.remove(userId);
                 eventPublisher.publishEvent(new SseDisconnectEvent(this, userId));
+                emitters.remove(userId);
             });
 
             emitter.onTimeout(() -> {
                 log.info("onTimeout 콜백 - userId: {}", userId);
-                emitter.complete();
-                emitters.remove(userId);
                 eventPublisher.publishEvent(new SseTimeoutEvent(this, userId));
+                emitter.complete();
+                emitters.remove(userId); // 명시적으로 제거
             });
 
             emitter.onError(e -> {
                 log.error("SseEmitter 오류 발생 - userId: {}, 오류: {}", userId, e.getMessage());
-                emitter.complete();
-                emitters.remove(userId);
                 eventPublisher.publishEvent(new SseDisconnectEvent(this, userId));
+                emitter.complete();
+                emitters.remove(userId); // 명시적으로 제거
             });
         }
         
         return emitter;
     }
 
-    @Scheduled(fixedRate = 180000) // 5분마다 실행
+    @Scheduled(fixedRate = 60000)
     public void sendHeartbeat() {
         eventPublisher.publishEvent(new SseHeartbeatEvent(this));
     }

--- a/morib/src/main/java/org/morib/server/global/sse/application/service/SseService.java
+++ b/morib/src/main/java/org/morib/server/global/sse/application/service/SseService.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.morib.server.global.common.Constants.SSE_EVENT_CONNECT;
@@ -72,5 +73,13 @@ public class SseService {
 
     public List<SseEmitter> fetchAllConnectedSseEmitters() {
         return sseRepository.getAllSseEmitters();
+    }
+
+    public int getConnectionCount() {
+        return sseRepository.getConnectionCount();
+    }
+
+    public Set<Long> getConnectedUserIds() {
+        return sseRepository.getConnectedUserIds();
     }
 }


### PR DESCRIPTION
## 📍 Issue
- closes #155 

## ✨ Key Changes
SSE 관련 메모리 이슈로 인한 어드민과 모니터링 로직을 추가했어요.

### 1. SseMonitorController

- 현재 메모리 사용량 및 SSE 연결 정보 조회
https://github.com/morib-in/Morib-Server-v2/blob/8713a3d19d168b209859d8ebb584c0842c125abf/morib/src/main/java/org/morib/server/global/sse/api/SseMonitorController.java#L32-L36

- 가비지 컬렉션 수동 실행 및 결과 반환
https://github.com/morib-in/Morib-Server-v2/blob/8713a3d19d168b209859d8ebb584c0842c125abf/morib/src/main/java/org/morib/server/global/sse/api/SseMonitorController.java#L51-L66

### 2. SseMemoryMonitor

- 1분 간격으로 메모리 사용량 및 SSE 연결 상태 로깅
- 각 연결의 세부 정보(ID, 카테고리, 경과 시간) 로깅
https://github.com/morib-in/Morib-Server-v2/blob/8713a3d19d168b209859d8ebb584c0842c125abf/morib/src/main/java/org/morib/server/global/sse/application/repository/SseMemoryMonitor.java#L18-L44

## 💬 To Reviewers
