### PR TITLE
Fix [#157] sse heartbeat 주기 단축

### DIFF
--- a/morib/src/main/java/org/morib/server/global/sse/application/repository/SseRepository.java
+++ b/morib/src/main/java/org/morib/server/global/sse/application/repository/SseRepository.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static org.morib.server.global.common.Constants.MAX_CONNECTION_TIME;
 import static org.morib.server.global.common.Constants.SSE_TIMEOUT;
 
 @Repository
@@ -25,9 +26,6 @@ public class SseRepository {
 
     public static final ConcurrentHashMap<Long, SseUserInfoWrapper> emitters = new ConcurrentHashMap<>();
     private final ApplicationEventPublisher eventPublisher;
-    
-    // 최대 연결 유지 시간 (기본값: 30분)
-    private static final long MAX_CONNECTION_TIME = 30 * 60 * 1000; // 30분
 
     public SseEmitter create() {
         return new SseEmitter(SSE_TIMEOUT);
@@ -79,7 +77,7 @@ public class SseRepository {
         return emitter;
     }
 
-    @Scheduled(fixedRate = 60000)
+    @Scheduled(fixedRate = 30000)
     public void sendHeartbeat() {
         eventPublisher.publishEvent(new SseHeartbeatEvent(this));
     }


### PR DESCRIPTION
## 📍 Issue
- closes #157 

## ✨ Key Changes
SSE 관련 이슈 해결 중, 다음 로그를 확인했습니다.

<img width="844" alt="스크린샷 2025-03-17 21 37 47" src="https://github.com/user-attachments/assets/973021b5-267a-4266-b1b2-da579cfe9c78" />

45초동안 아무 일도 일어나지 않아 계속해서 refresh 요청을 날리는 것 같아, heart-beat 주기를 30초로 단축했습니다.

```java
@Scheduled(fixedRate = 30000)
    public void sendHeartbeat() {
        eventPublisher.publishEvent(new SseHeartbeatEvent(this));
    }
```

## 💬 To Reviewers
