### PR TITLE
Fix [#159] SSE heart-beat 수정

### DIFF
--- a/morib/src/main/java/org/morib/server/global/common/Constants.java
+++ b/morib/src/main/java/org/morib/server/global/common/Constants.java
@@ -27,7 +27,7 @@ public final class Constants {
     public static final String SSE_EVENT_TIMER_STOP_ACTION = "timerStopAction";
     public static final String SSE_EVENT_FRIEND_REQUEST = "friendRequest";
     public static final String SSE_EVENT_FRIEND_REQUEST_ACCEPT = "friendRequestAccept";
-    public static final String SSE_EVENT_HEARTBEAT = "heartbeat";
+    public static final String SSE_EVENT_HEARTBEAT = ": heartbeat\n\n";
     public static final int MAX_VISIBLE_ALLOWED_SERVICES = 5;
 
 

--- a/morib/src/main/java/org/morib/server/global/sse/api/SseController.java
+++ b/morib/src/main/java/org/morib/server/global/sse/api/SseController.java
@@ -26,7 +26,7 @@ public class SseController {
         return ResponseEntity.ok(emitter);
     }
 
-    @GetMapping("/sse/refresh")
+    @GetMapping(value = "/sse/refresh", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public ResponseEntity<SseEmitter> refresh(@AuthenticationPrincipal CustomUserDetails customUserDetails,
                                               @RequestHeader(required = false) String elapsedTime,
                                               @RequestHeader(required = false) String runningCategoryName,

--- a/morib/src/main/java/org/morib/server/global/sse/api/SseEventHandler.java
+++ b/morib/src/main/java/org/morib/server/global/sse/api/SseEventHandler.java
@@ -38,8 +38,6 @@ public class SseEventHandler {
     @EventListener
     public void handleSseTimeout(SseTimeoutEvent event) {
         log.info("SseTimeoutEvent received for userId: {}", event.getUserId());
-        List<Long> targetUserIds = fetchRelationshipService.fetchConnectedRelationshipAndClassify(event.getUserId());
-        List<SseEmitter> targetEmitters = sseService.fetchConnectedSseEmittersById(targetUserIds);
         sseSender.sendEvent(sseService.fetchSseEmitterByUserId(event.getUserId()), SSE_EVENT_TIME_OUT, sseMessageBuilder.buildTimeoutMessage(event.getUserId()));
     }
 
@@ -47,6 +45,6 @@ public class SseEventHandler {
     public void handleSseHeartbeat(SseHeartbeatEvent event) {
         log.info("SseHeartbeat received");
         List<SseEmitter> targetEmitters = sseService.fetchAllConnectedSseEmitters();
-        sseSender.broadcast(targetEmitters, SSE_EVENT_HEARTBEAT, sseMessageBuilder.buildHeartbeatMessage());
+        sseSender.sendHeartbeat(targetEmitters);
     }
 }


### PR DESCRIPTION
## 📍 Issue
- closes #159 

## ✨ Key Changes
이전 PR에서의 문제가 해결되지 않아 추가적으로 변경사항을 반영합니다.
- SSE heart-beat가 클라이언트에게 제대로 인식되지 않을 수 있어, 이벤트 발송이 아닌 comment를 발송하도록 변경했습니다.

```java
public static final String SSE_EVENT_HEARTBEAT = ": heartbeat\n\n";

targetEmitter.send(SseEmitter.event()
                            .comment(SSE_EVENT_HEARTBEAT));
```

- 기존 refresh 컨트롤러 코드에서 반환 타입이 text/event-stream 방식이 적용되어있지 않아 수정했습니다.
```java
@GetMapping(value = "/sse/refresh", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
```

## 💬 To Reviewers
