### PR TITLE
Refactor [#161] Todo 및 SSE 관련 변경사항 반영

### DIFF
--- a/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
@@ -32,10 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.LocalDate;
-import java.util.Comparator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.morib.server.global.common.Constants.SSE_EVENT_TIMER_START;
@@ -99,9 +96,13 @@ public class TimerViewFacade {
      */
     @Transactional
     public TodoCardResponseDto fetchTodoCard(Long userId, LocalDate targetDate) {
-        Todo todo = fetchTodoService.fetchByUserIdAndTargetDate(userId, targetDate);
-        LinkedHashSet<Task> tasks = fetchTaskService.fetchByTodoAndSameTargetDate(todo, targetDate);
         int totalTimeOfToday = fetchTimerService.sumElapsedTimeByUser(fetchUserService.fetchByUserId(userId), targetDate);
+        Optional<Todo> todo = fetchTodoService.fetchByUserIdAndTargetDate(userId, targetDate);
+
+        if (todo.isEmpty()) return new TodoCardResponseDto(totalTimeOfToday, Collections.emptyList());
+
+        LinkedHashSet<Task> tasks = fetchTaskService.fetchByTodoAndSameTargetDate(todo.get(), targetDate);
+
         List<TaskInTodoCardDto> taskInTodoCardDtos = tasks.stream()
             .map(t -> getTaskInTodoCardDto(targetDate, t))
             .toList();

--- a/morib/src/main/java/org/morib/server/domain/todo/application/FetchTodoService.java
+++ b/morib/src/main/java/org/morib/server/domain/todo/application/FetchTodoService.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface FetchTodoService {
     Optional<Todo> fetchOrNullByUserIdAndTargetDate(Long mockUserId, LocalDate targetDate);
-    Todo fetchByUserIdAndTargetDate(Long userId, LocalDate targetDate);
+    Optional<Todo> fetchByUserIdAndTargetDate(Long userId, LocalDate targetDate);
 }

--- a/morib/src/main/java/org/morib/server/domain/todo/application/FetchTodoServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/todo/application/FetchTodoServiceImpl.java
@@ -6,8 +6,6 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.morib.server.domain.todo.infra.Todo;
 import org.morib.server.domain.todo.infra.TodoRepository;
-import org.morib.server.global.exception.NotFoundException;
-import org.morib.server.global.message.ErrorMessage;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -22,9 +20,8 @@ public class FetchTodoServiceImpl implements FetchTodoService {
     }
 
     @Override
-    public Todo fetchByUserIdAndTargetDate(Long userId, LocalDate targetDate) {
-        return todoRepository.findTodoByUserIdAndTargetDate(userId, targetDate)
-            .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+    public Optional<Todo> fetchByUserIdAndTargetDate(Long userId, LocalDate targetDate) {
+        return todoRepository.findTodoByUserIdAndTargetDate(userId, targetDate);
     }
 
 }

--- a/morib/src/main/java/org/morib/server/global/common/Constants.java
+++ b/morib/src/main/java/org/morib/server/global/common/Constants.java
@@ -27,7 +27,7 @@ public final class Constants {
     public static final String SSE_EVENT_TIMER_STOP_ACTION = "timerStopAction";
     public static final String SSE_EVENT_FRIEND_REQUEST = "friendRequest";
     public static final String SSE_EVENT_FRIEND_REQUEST_ACCEPT = "friendRequestAccept";
-    public static final String SSE_EVENT_HEARTBEAT = ": heartbeat\n\n";
+    public static final String SSE_EVENT_HEARTBEAT = "heartbeat";
     public static final int MAX_VISIBLE_ALLOWED_SERVICES = 5;
 
 

--- a/morib/src/main/java/org/morib/server/global/sse/api/SseController.java
+++ b/morib/src/main/java/org/morib/server/global/sse/api/SseController.java
@@ -29,8 +29,8 @@ public class SseController {
     @GetMapping(value = "/sse/refresh", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public ResponseEntity<SseEmitter> refresh(@AuthenticationPrincipal CustomUserDetails customUserDetails,
                                               @RequestHeader(required = false) String elapsedTime,
-                                              @RequestHeader(required = false) String runningCategoryName,
-                                              @RequestHeader(required = false) String taskId){
+                                              @RequestHeader(required = false) String taskId,
+                                              @RequestParam("runningCategoryName") String runningCategoryName) {
         Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
         SseEmitter emitter = sseFacade.refresh(userId, UserInfoDtoForSseUserInfoWrapper.of(
                 userId,

--- a/morib/src/main/java/org/morib/server/global/sse/api/SseEventHandler.java
+++ b/morib/src/main/java/org/morib/server/global/sse/api/SseEventHandler.java
@@ -45,6 +45,6 @@ public class SseEventHandler {
     public void handleSseHeartbeat(SseHeartbeatEvent event) {
         log.info("SseHeartbeat received");
         List<SseEmitter> targetEmitters = sseService.fetchAllConnectedSseEmitters();
-        sseSender.sendHeartbeat(targetEmitters);
+        sseSender.broadcast(targetEmitters, SSE_EVENT_HEARTBEAT, sseMessageBuilder.buildHeartbeatMessage());
     }
 }

--- a/morib/src/main/java/org/morib/server/global/sse/application/repository/SseMemoryMonitor.java
+++ b/morib/src/main/java/org/morib/server/global/sse/application/repository/SseMemoryMonitor.java
@@ -19,9 +19,6 @@ public class SseMemoryMonitor {
     public void logMemoryUsage() {
         Runtime runtime = Runtime.getRuntime();
         
-        // 가비지 컬렉션 실행
-        System.gc();
-        
         long usedMemory = runtime.totalMemory() - runtime.freeMemory();
         int connectionCount = sseRepository.getConnectionCount();
         

--- a/morib/src/main/java/org/morib/server/global/sse/application/service/SseSender.java
+++ b/morib/src/main/java/org/morib/server/global/sse/application/service/SseSender.java
@@ -109,7 +109,8 @@ public class SseSender {
             try {
                 if (targetEmitter != null) {
                     targetEmitter.send(SseEmitter.event()
-                            .comment(SSE_EVENT_HEARTBEAT));
+                            .name(SSE_EVENT_HEARTBEAT)
+                            .data(": heartbeat \n\n"));
                 }
             } catch (IOException e) {
                 log.error("SSE 브로드캐스트 실패: {}", e.getMessage());


### PR DESCRIPTION
## 📍 Issue
- closes #161 

## ✨ Key Changes
- 오늘 할 일 카드를 조회하는 api에서 조회 결과가 없으면 NPE가 아닌 빈 배열로 리턴되도록 수정했습니다.

```java
public TodoCardResponseDto fetchTodoCard(Long userId, LocalDate targetDate) {
    int totalTimeOfToday = fetchTimerService.sumElapsedTimeByUser(fetchUserService.fetchByUserId(userId), targetDate);
    Optional<Todo> todo = fetchTodoService.fetchByUserIdAndTargetDate(userId, targetDate);

    if (todo.isEmpty()) return new TodoCardResponseDto(totalTimeOfToday, Collections.emptyList());

    LinkedHashSet<Task> tasks = fetchTaskService.fetchByTodoAndSameTargetDate(todo.get(), targetDate);
```

- SSE Refresh 로직 시 인코딩 이슈로 인해 `runningCategoryName`은 Query Parameter로 수정했습니다.

```java
@RequestParam("runningCategoryName") String runningCategoryName) {

```

- 가비지 컬렉션을 직접 호출하는 코드는 제거했습니다.

## 💬 To Reviewers
