### PR TITLE
Fix [#163] SSE 관련 버그 일체 수정

### DIFF
--- a/morib/src/main/java/org/morib/server/domain/category/application/FetchCategoryService.java
+++ b/morib/src/main/java/org/morib/server/domain/category/application/FetchCategoryService.java
@@ -16,4 +16,5 @@ public interface FetchCategoryService {
     CategoryWithTasks convertToCategoryWithTasks(Category category, LinkedHashSet<TaskWithTimers> taskWithTimers);
     Category fetchByUserAndCategoryId(User findUser, Long categoryId);
     List<Category> fetchByUserIdAndTasksAndTimers(Long userId);
+    Category fetchByUserIdAndTaskId(Long userId, Long taskId);
 }

--- a/morib/src/main/java/org/morib/server/domain/category/application/FetchCategoryServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/category/application/FetchCategoryServiceImpl.java
@@ -43,4 +43,9 @@ public class FetchCategoryServiceImpl implements FetchCategoryService{
         return categoryRepository.findByUserIdAndFetchTasksAndTimers(userId);
     }
 
+    @Override
+    public Category fetchByUserIdAndTaskId(Long userId, Long taskId) {
+        return categoryRepository.findByUserIdAndTaskId(userId, taskId);
+    }
+
 }

--- a/morib/src/main/java/org/morib/server/domain/category/infra/CategoryRepository.java
+++ b/morib/src/main/java/org/morib/server/domain/category/infra/CategoryRepository.java
@@ -16,4 +16,12 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
             "WHERE c.user.id = :userId " +
             "ORDER BY c.createdAt ASC ")
     List<Category> findByUserIdAndFetchTasksAndTimers(Long userId);
+
+    @Query("SELECT c FROM Category c " +
+            "LEFT JOIN FETCH c.tasks t " +
+            "LEFT JOIN FETCH t.timers ti " +
+            "WHERE c.user.id = :userId " +
+            "AND t.id = :taskId")
+    Category findByUserIdAndTaskId(Long userId, Long taskId);
+
 }

--- a/morib/src/main/java/org/morib/server/domain/timer/application/FetchTimerService.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/application/FetchTimerService.java
@@ -16,4 +16,7 @@ public interface FetchTimerService {
     List<Timer> fetchByUserAndTargetDate(User user, LocalDate targetDate);
     int sumElapsedTimeByUser(User user, LocalDate targetDate);
     Set<Long> fetchExistingTaskIdsByTargetDate(List<Task> tasks, LocalDate targetDate);
+    Timer fetchByTaskIdAndTargetDate(Long taskId, LocalDate targetDate);
+
+
 }

--- a/morib/src/main/java/org/morib/server/domain/timer/application/FetchTimerServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/application/FetchTimerServiceImpl.java
@@ -67,4 +67,9 @@ public class FetchTimerServiceImpl implements FetchTimerService{
         return timerRepository.findExistingTaskIdsByTargetDate(taskIds, targetDate);
     }
 
+    @Override
+    public Timer fetchByTaskIdAndTargetDate(Long taskId, LocalDate targetDate) {
+        return timerRepository.findByTaskIdAndTargetDate(taskId, targetDate);
+    }
+
 }

--- a/morib/src/main/java/org/morib/server/domain/timer/infra/TimerRepository.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/infra/TimerRepository.java
@@ -14,5 +14,5 @@ public interface TimerRepository extends JpaRepository<Timer, Long> {
     List<Timer> findByUser(User user);
     @Query("SELECT t.task.id FROM Timer t WHERE t.task.id IN :taskIds AND t.targetDate = :targetDate")
     Set<Long> findExistingTaskIdsByTargetDate(List<Long> taskIds, LocalDate targetDate);
-
+    Timer findByTaskIdAndTargetDate(Long taskId, LocalDate targetDate);
 }

--- a/morib/src/main/java/org/morib/server/domain/timer/infra/TimerStatus.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/infra/TimerStatus.java
@@ -1,0 +1,5 @@
+package org.morib.server.domain.timer.infra;
+
+public enum TimerStatus {
+    RUNNING, PAUSED
+}

--- a/morib/src/main/java/org/morib/server/global/message/ErrorMessage.java
+++ b/morib/src/main/java/org/morib/server/global/message/ErrorMessage.java
@@ -17,6 +17,7 @@ public enum ErrorMessage {
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, "유효하지 않은 이메일 형식입니다."),
     INVALID_TASK_IN_TODO(HttpStatus.BAD_REQUEST, "완료된 태스크는 할 일에 추가하거나 타이머를 실행할 수 없습니다."),
     CANNOT_ADD_YOURSELF(HttpStatus.BAD_REQUEST, "자기 자신을 친구로 추가할 수 없습니다."),
+    WITHOUT_TIMER_STATUS(HttpStatus.BAD_REQUEST, "timerStatus 값이 없습니다. Request Header에 추가했는지 확인해주세요."),
     /**
      * 401 Unauthorized
      */

--- a/morib/src/main/java/org/morib/server/global/message/SseMessageBuilder.java
+++ b/morib/src/main/java/org/morib/server/global/message/SseMessageBuilder.java
@@ -9,15 +9,15 @@ import org.springframework.stereotype.Component;
 public class SseMessageBuilder {
 
     public String buildConnectionMessage(Long userId) {
-        return "[id : " + userId + "] 가 연결되었습니다.";
+        return "[userId : " + userId + "] 가 연결되었습니다.";
     }
 
     public String buildDisconnectionMessage(Long userId) {
-        return "[id : " + userId + "] 과의 연결이 종료되었습니다.";
+        return "[userId : " + userId + "] 과의 연결이 종료되었습니다.";
     }
 
     public String buildTimeoutMessage(Long userId) {
-        return "[id : " + userId + "] 님의 연결 유지 시간이 만료되었습니다.";
+        return "[userId : " + userId + "] 님의 연결 유지 시간이 만료되었습니다.";
     }
 
     public String buildFriendRequestMessage(String userName) {

--- a/morib/src/main/java/org/morib/server/global/sse/api/SseController.java
+++ b/morib/src/main/java/org/morib/server/global/sse/api/SseController.java
@@ -2,6 +2,13 @@ package org.morib.server.global.sse.api;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.morib.server.domain.timer.infra.TimerStatus;
+import org.morib.server.global.common.ApiResponseUtil;
+import org.morib.server.global.common.BaseResponse;
+import org.morib.server.global.exception.InvalidQueryParameterException;
+import org.morib.server.global.message.ErrorMessage;
+import org.morib.server.global.message.SuccessMessage;
+import org.morib.server.global.sse.application.service.SseService;
 import org.morib.server.global.userauth.CustomUserDetails;
 import org.morib.server.global.userauth.PrincipalHandler;
 import org.springframework.http.MediaType;
@@ -18,6 +25,7 @@ public class SseController {
 
     private final PrincipalHandler principalHandler;
     private final SseFacade sseFacade;
+    private final SseService sseService;
 
     @GetMapping(value = "/sse/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public ResponseEntity<SseEmitter> connect(@AuthenticationPrincipal CustomUserDetails customUserDetails){
@@ -26,18 +34,17 @@ public class SseController {
         return ResponseEntity.ok(emitter);
     }
 
-    @GetMapping(value = "/sse/refresh", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public ResponseEntity<SseEmitter> refresh(@AuthenticationPrincipal CustomUserDetails customUserDetails,
-                                              @RequestHeader(required = false) String elapsedTime,
-                                              @RequestHeader(required = false) String taskId,
-                                              @RequestParam("runningCategoryName") String runningCategoryName) {
+    // 재연결 로직이 아닌 사용자 정보 업데이트용 api
+    @GetMapping(value = "/sse/refresh")
+    public ResponseEntity<BaseResponse<?>> refresh(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                @RequestHeader(required = false) String elapsedTime,
+                                @RequestHeader(required = false) String taskId,
+                                @RequestHeader(required = false) TimerStatus timerStatus){
         Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
-        SseEmitter emitter = sseFacade.refresh(userId, UserInfoDtoForSseUserInfoWrapper.of(
-                userId,
-                elapsedTime == null ? 0 : Integer.parseInt(elapsedTime),
-                runningCategoryName == null ? "" : runningCategoryName,
-                taskId == null ? null : Long.parseLong(taskId)));
-        return ResponseEntity.ok(emitter);
+        int convertedElapsedTime = elapsedTime == null ? 0 : Integer.parseInt(elapsedTime);
+        Long convertedTaskId = taskId == null ? null : Long.parseLong(taskId);
+        sseFacade.refresh(userId, convertedElapsedTime, convertedTaskId, timerStatus);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 
 }

--- a/morib/src/main/java/org/morib/server/global/sse/api/SseFacade.java
+++ b/morib/src/main/java/org/morib/server/global/sse/api/SseFacade.java
@@ -39,8 +39,22 @@ public class SseFacade {
 
     public SseEmitter init(Long userId) {
         try {
+            // 기존 연결이 있으면 종료
+            sseService.removeExistingEmitter(userId);
             SseEmitter createdEmitter = sseService.create();
-            sseService.add(userId, createdEmitter);
+
+            for (int i=0; i<10; i++) {
+                if (!sseService.validateConnection(userId)) {
+                    // emitter 생성 후 저장
+                    sseService.add(userId, createdEmitter);
+                    break;
+                }
+                else {
+                    log.info("SseEmitter is already connected. Retry to connect ... count : {}", i);
+                    Thread.sleep(10);
+                }
+            }
+            // 브로드캐스트
             return broadcastAllAfterCreated(userId, createdEmitter, SSE_EVENT_CONNECT);
         } catch (Exception e) {
             log.error("SSE 초기화 중 오류 발생: {}", e.getMessage(), e);

--- a/morib/src/main/java/org/morib/server/global/sse/api/SseMonitorController.java
+++ b/morib/src/main/java/org/morib/server/global/sse/api/SseMonitorController.java
@@ -4,14 +4,17 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.morib.server.global.sse.application.repository.SseMemoryMonitor;
 import org.morib.server.global.sse.application.repository.SseRepository;
+import org.morib.server.global.sse.application.repository.SseUserInfoWrapper;
 import org.morib.server.global.sse.application.service.SseService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,6 +23,7 @@ import java.util.Map;
 public class SseMonitorController {
 
     private final SseService sseService;
+    private final SseRepository sseRepository;
 
     @GetMapping("/sse/monitor")
     public ResponseEntity<Map<String, Object>> getMemoryUsage() {
@@ -64,6 +68,109 @@ public class SseMonitorController {
         result.put("afterGcMemoryMB", afterGcMemory / (1024 * 1024));
         result.put("freedMemoryMB", (beforeGcMemory - afterGcMemory) / (1024 * 1024));
         result.put("sseConnectionCount", sseService.getConnectionCount());
+        
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/sse/userInfo")
+    public ResponseEntity<Map<String, Object>> getUserInfo() {
+        Map<String, Object> result = new HashMap<>();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        
+        // 연결 수와 총괄 정보
+        int connectionCount = sseService.getConnectionCount();
+        result.put("totalConnections", connectionCount);
+        result.put("timestamp", new Date().toString());
+        
+        // 사용자별 상세 정보
+        List<Map<String, Object>> userDetailsList = new ArrayList<>();
+        
+        Set<Long> connectedUserIds = sseService.getConnectedUserIds();
+        for (Long userId : connectedUserIds) {
+            Map<String, Object> userDetails = new HashMap<>();
+            userDetails.put("userId", userId);
+            
+            // SseEmitter 정보
+            SseEmitter emitter = sseRepository.getSseEmitterById(userId);
+            if (emitter != null) {
+                userDetails.put("emitterHashCode", emitter.hashCode());
+                userDetails.put("emitterClass", emitter.getClass().getName());
+            } else {
+                userDetails.put("emitterStatus", "NULL");
+            }
+            
+            // SseUserInfoWrapper 정보
+            SseUserInfoWrapper userInfo = sseRepository.getSseUserInfoWrapperById(userId);
+            if (userInfo != null) {
+                Map<String, Object> userInfoMap = new HashMap<>();
+                userInfoMap.put("elapsedTime", userInfo.getElapsedTime());
+                userInfoMap.put("runningCategoryName", userInfo.getRunningCategoryName());
+                userInfoMap.put("taskId", userInfo.getTaskId());
+                userInfoMap.put("timerStatus", userInfo.getTimerStatus() != null ? userInfo.getTimerStatus().name() : "NULL");
+                
+                if (userInfo.getLastTimerStatusChangeTime() != null) {
+                    userInfoMap.put("lastTimerStatusChangeTime", userInfo.getLastTimerStatusChangeTime().format(formatter));
+                } else {
+                    userInfoMap.put("lastTimerStatusChangeTime", "NULL");
+                }
+                
+                userDetails.put("userInfo", userInfoMap);
+            } else {
+                userDetails.put("userInfo", "NULL");
+            }
+            
+            userDetailsList.add(userDetails);
+        }
+        
+        // 타이머 상태별 통계
+        Map<String, Long> timerStatusStats = new HashMap<>();
+        long runningCount = userDetailsList.stream()
+                .filter(details -> {
+                    Object userInfoObj = details.get("userInfo");
+                    if (!(userInfoObj instanceof Map)) {
+                        return false;
+                    }
+                    Map<String, Object> userInfo = (Map<String, Object>) userInfoObj;
+                    return "RUNNING".equals(userInfo.get("timerStatus"));
+                })
+                .count();
+        
+        long pausedCount = userDetailsList.stream()
+                .filter(details -> {
+                    Object userInfoObj = details.get("userInfo");
+                    if (!(userInfoObj instanceof Map)) {
+                        return false;
+                    }
+                    Map<String, Object> userInfo = (Map<String, Object>) userInfoObj;
+                    return "PAUSED".equals(userInfo.get("timerStatus"));
+                })
+                .count();
+        
+        timerStatusStats.put("RUNNING", runningCount);
+        timerStatusStats.put("PAUSED", pausedCount);
+        timerStatusStats.put("NULL_OR_UNKNOWN", connectionCount - runningCount - pausedCount);
+        
+        result.put("userDetails", userDetailsList);
+        result.put("timerStatusStats", timerStatusStats);
+        
+        // 메모리 정보 추가
+        Runtime runtime = Runtime.getRuntime();
+        long totalMemory = runtime.totalMemory();
+        long freeMemory = runtime.freeMemory();
+        long usedMemory = totalMemory - freeMemory;
+        
+        Map<String, Object> memoryInfo = new HashMap<>();
+        memoryInfo.put("totalMemoryMB", totalMemory / (1024 * 1024));
+        memoryInfo.put("freeMemoryMB", freeMemory / (1024 * 1024));
+        memoryInfo.put("usedMemoryMB", usedMemory / (1024 * 1024));
+        
+        if (connectionCount > 0) {
+            memoryInfo.put("averageMemoryPerConnectionKB", (usedMemory / connectionCount) / 1024);
+        } else {
+            memoryInfo.put("averageMemoryPerConnectionKB", 0);
+        }
+        
+        result.put("memoryInfo", memoryInfo);
         
         return ResponseEntity.ok(result);
     }

--- a/morib/src/main/java/org/morib/server/global/sse/api/UserInfoDtoForSseUserInfoWrapper.java
+++ b/morib/src/main/java/org/morib/server/global/sse/api/UserInfoDtoForSseUserInfoWrapper.java
@@ -1,12 +1,12 @@
 package org.morib.server.global.sse.api;
 
 public record UserInfoDtoForSseUserInfoWrapper(
-        Long id,
+        Long userId,
         int elapsedTime,
         String runningCategoryName,
         Long taskId
 ) {
-    public static UserInfoDtoForSseUserInfoWrapper of(Long id, int elapsedTime, String runningCategoryName, Long taskId) {
-        return new UserInfoDtoForSseUserInfoWrapper(id, elapsedTime, runningCategoryName, taskId);
+    public static UserInfoDtoForSseUserInfoWrapper of(Long userId, int elapsedTime, String runningCategoryName, Long taskId) {
+        return new UserInfoDtoForSseUserInfoWrapper(userId, elapsedTime, runningCategoryName, taskId);
     }
 }

--- a/morib/src/main/java/org/morib/server/global/sse/application/repository/SseMemoryMonitor.java
+++ b/morib/src/main/java/org/morib/server/global/sse/application/repository/SseMemoryMonitor.java
@@ -5,9 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-/**
- * SSE 연결의 메모리 사용량을 모니터링하는 클래스
- */
 @Component
 @Slf4j
 @RequiredArgsConstructor
@@ -31,11 +28,5 @@ public class SseMemoryMonitor {
         if (connectionCount > 0) {
             log.info("Estimated memory per connection: {} KB", (usedMemory / connectionCount) / 1024);
         }
-        
-        // 각 연결의 세부 정보 로깅
-        SseRepository.emitters.forEach((userId, wrapper) -> {
-            log.debug("Connection ID: {}, Category: {}, ElapsedTime: {}", 
-                    userId, wrapper.getRunningCategoryName(), wrapper.getElapsedTime());
-        });
     }
 } 

--- a/morib/src/main/java/org/morib/server/global/sse/application/repository/SseRepository.java
+++ b/morib/src/main/java/org/morib/server/global/sse/application/repository/SseRepository.java
@@ -77,6 +77,19 @@ public class SseRepository {
         return emitter;
     }
 
+    public SseUserInfoWrapper mergeUserInfoWrapper(Long userId, SseUserInfoWrapper userInfoWrapper) {
+        userInfos.merge(userId, userInfoWrapper, (oldValue, newValue) -> {
+            oldValue.setElapsedTime(oldValue.getElapsedTime() + newValue.getElapsedTime());
+            oldValue.setRunningCategoryName(newValue.getRunningCategoryName());
+            oldValue.setTaskId(newValue.getTaskId());
+            oldValue.setTimerStatus(newValue.getTimerStatus());
+            oldValue.setLastTimerStatusChangeTime(LocalDateTime.now());
+            return oldValue;
+        });
+        return userInfos.get(userId);
+    }
+
+
     @Scheduled(fixedRate = 30000)
     public void sendHeartbeat() {
         eventPublisher.publishEvent(new SseHeartbeatEvent(this));

--- a/morib/src/main/java/org/morib/server/global/sse/application/repository/SseRepository.java
+++ b/morib/src/main/java/org/morib/server/global/sse/application/repository/SseRepository.java
@@ -2,6 +2,9 @@ package org.morib.server.global.sse.application.repository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.morib.server.global.exception.SSEConnectionException;
+import org.morib.server.global.message.ErrorMessage;
+import org.morib.server.global.message.SseMessageBuilder;
 import org.morib.server.global.sse.application.event.SseDisconnectEvent;
 import org.morib.server.global.sse.application.event.SseHeartbeatEvent;
 import org.morib.server.global.sse.application.event.SseTimeoutEvent;
@@ -10,13 +13,14 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static org.morib.server.global.common.Constants.MAX_CONNECTION_TIME;
 import static org.morib.server.global.common.Constants.SSE_TIMEOUT;
 
 @Repository
@@ -24,53 +28,68 @@ import static org.morib.server.global.common.Constants.SSE_TIMEOUT;
 @RequiredArgsConstructor
 public class SseRepository {
 
-    public static final ConcurrentHashMap<Long, SseUserInfoWrapper> emitters = new ConcurrentHashMap<>();
+    public static final ConcurrentHashMap<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+    public static final ConcurrentHashMap<Long, SseUserInfoWrapper> userInfos = new ConcurrentHashMap<>();
+
     private final ApplicationEventPublisher eventPublisher;
+    private final SseMessageBuilder sseMessageBuilder;
 
     public SseEmitter create() {
         return new SseEmitter(SSE_TIMEOUT);
     }
 
+    public void removeInvalidEmitter(SseEmitter emitter) {
+        if (emitter != null && emitters.containsValue(emitter)) {
+            try {
+                log.info("유효하지 않은 SseEmitter 제거: {}", emitter);
+                emitter.completeWithError(new Exception("유효하지 않은 연결"));
+                emitters.values().remove(emitter);
+            } catch (Exception e) {
+                log.warn("SseEmitter 완료 처리 중 오류 발생: {}", e.getMessage());
+                emitters.values().remove(emitter);
+            }
+        }
+
+    }
+
     public void removeExistingEmitter(Long userId) {
         if (emitters.containsKey(userId)) {
-            SseEmitter oldEmitter = emitters.get(userId).getSseEmitter();
+            SseEmitter oldEmitter = emitters.get(userId);
             if (oldEmitter != null) {
                 try {
+                    log.info("기존 SseEmitter 제거: {}", oldEmitter);
                     oldEmitter.complete();
                 } catch (Exception e) {
+                    oldEmitter.completeWithError(e);
                     log.warn("기존 SseEmitter 완료 처리 중 오류 발생: {}", e.getMessage());
                 }
             }
-            emitters.remove(userId);
+//            emitters.remove(userId);
         }
     }
 
-    public SseEmitter add(Long userId, SseEmitter emitter, int elapsedTime, String runningCategoryName, Long taskId) {
-        removeExistingEmitter(userId);
-
-        emitters.put(userId, new SseUserInfoWrapper(emitter, elapsedTime, runningCategoryName, taskId));
-        log.info("새 emitter 추가됨: {}", emitter);
+    public SseEmitter addSseEmitter(Long userId, SseEmitter emitter) {
+        emitters.put(userId, emitter);
+        log.info("새 userId : {} 의 emitter 추가됨: {}", userId, emitter);
         log.info("emitter 목록 크기: {}", emitters.size());
         
         if (emitter != null) {
             emitter.onCompletion(() -> {
-                log.info("onCompletion 콜백 - userId: {}", userId);
+                log.info("onCompletion 콜백 - userId: {}, emitter: {}", userId, emitter);
                 eventPublisher.publishEvent(new SseDisconnectEvent(this, userId));
-                emitters.remove(userId);
+                emitters.remove(userId, emitter);
             });
 
             emitter.onTimeout(() -> {
-                log.info("onTimeout 콜백 - userId: {}", userId);
-                eventPublisher.publishEvent(new SseTimeoutEvent(this, userId));
+                log.info("onTimeout 콜백 - userId: {}, emitter: {}", userId, emitter);
                 emitter.complete();
-                emitters.remove(userId); // 명시적으로 제거
             });
 
             emitter.onError(e -> {
-                log.error("SseEmitter 오류 발생 - userId: {}, 오류: {}", userId, e.getMessage());
+                log.error("SseEmitter 오류 발생 - userId: {}, 오류: {}, emitter: {}", userId, e.getMessage(), emitter);
                 eventPublisher.publishEvent(new SseDisconnectEvent(this, userId));
-                emitter.complete();
-                emitters.remove(userId); // 명시적으로 제거
+                emitter.completeWithError(e);
+//                emitters.remove(userId, emitter); // 명시적으로 제거
             });
         }
         
@@ -97,38 +116,27 @@ public class SseRepository {
 
     @Scheduled(fixedRate = 600000) // 10분마다 실행
     public void cleanupStaleConnections() {
-        log.info("오래된 SSE 연결 정리 시작...");
-        long currentTime = System.currentTimeMillis();
+        log.info("== Null인 SSE 연결 정리 시작... ==");
         int removedCount = 0;
         
-        for (Map.Entry<Long, SseUserInfoWrapper> entry : emitters.entrySet()) {
-            SseEmitter emitter = entry.getValue().getSseEmitter();
-            if (emitter != null) {
-                // 연결 시간이 MAX_CONNECTION_TIME을 초과하면 제거
-                if (currentTime - emitter.hashCode() > MAX_CONNECTION_TIME) {
-                    try {
-                        emitter.complete();
-                    } catch (Exception e) {
-                        log.warn("오래된 연결 완료 처리 중 오류 발생: {}", e.getMessage());
-                    }
-                    emitters.remove(entry.getKey());
-                    removedCount++;
-                    
-                    // 연결 종료 이벤트 발행
-                    eventPublisher.publishEvent(new SseDisconnectEvent(this, entry.getKey()));
-                }
-            } else {
+        for (Map.Entry<Long, SseEmitter> entry : emitters.entrySet()) {
+            SseEmitter emitter = entry.getValue();
+            if (emitter == null) {
                 // emitter가 null인 경우 제거
                 emitters.remove(entry.getKey());
                 removedCount++;
             }
         }
         
-        log.info("오래된 SSE 연결 정리 완료. 제거된 연결 수: {}, 남은 연결 수: {}", removedCount, emitters.size());
+        log.info("== NULL SSE 연결 정리 완료. 제거된 연결 수: {}, 남은 연결 수: {} == \n", removedCount, emitters.size());
     }
 
     public SseEmitter getSseEmitterById(Long id) {
-        return emitters.get(id) == null ? null : emitters.get(id).getSseEmitter();
+        return emitters.get(id) == null ? null : emitters.get(id);
+    }
+
+    public SseUserInfoWrapper getSseUserInfoWrapperById(Long id) {
+        return emitters.get(id) == null ? null : userInfos.get(id);
     }
 
     public boolean isConnected(Long userId) {
@@ -137,7 +145,6 @@ public class SseRepository {
 
     public List<SseEmitter> getAllSseEmitters() {
         return emitters.values().stream()
-                .map(SseUserInfoWrapper::getSseEmitter)
                 .filter(Objects::nonNull)
                 .toList();
     }
@@ -149,4 +156,6 @@ public class SseRepository {
     public Set<Long> getConnectedUserIds() {
         return emitters.keySet();
     }
+
+
 }

--- a/morib/src/main/java/org/morib/server/global/sse/application/repository/SseUserInfoWrapper.java
+++ b/morib/src/main/java/org/morib/server/global/sse/application/repository/SseUserInfoWrapper.java
@@ -3,20 +3,25 @@ package org.morib.server.global.sse.application.repository;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.morib.server.domain.timer.infra.TimerStatus;
 import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.time.LocalDateTime;
 
 @Component
 @RequiredArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 public class SseUserInfoWrapper {
-    private SseEmitter sseEmitter;
     private int elapsedTime;
     private String runningCategoryName;
     private Long taskId;
+    private TimerStatus timerStatus;
+    private LocalDateTime lastTimerStatusChangeTime;
 
-    public static SseUserInfoWrapper create(SseEmitter sseEmitter, int elapsedTime, String runningCategoryName, Long taskId) {
-        return new SseUserInfoWrapper(sseEmitter, elapsedTime, runningCategoryName, taskId);
+    public static SseUserInfoWrapper of(int elapsedTime, String runningCategoryName, Long taskId, TimerStatus timerStatus, LocalDateTime lastTimerStatusChangeTime) {
+        return new SseUserInfoWrapper(elapsedTime, runningCategoryName, taskId, timerStatus, lastTimerStatusChangeTime);
     }
 }

--- a/morib/src/main/java/org/morib/server/global/sse/application/service/SseSender.java
+++ b/morib/src/main/java/org/morib/server/global/sse/application/service/SseSender.java
@@ -78,6 +78,7 @@ public class SseSender {
             } catch (IOException e) {
                 log.error("SSE 브로드캐스트 실패: {}", e.getMessage());
                 targetEmitter.completeWithError(e);
+
             } catch (Exception e) {
                 log.error("SSE 브로드캐스트 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
                 targetEmitter.completeWithError(e);
@@ -94,32 +95,6 @@ public class SseSender {
         
         // 실패 카운터 재설정
         failedSendAttempts.set(0);
-    }
-
-    public void sendHeartbeat(List<SseEmitter> emitters) {
-        String eventName = "heartbeat";
-        if (emitters == null || emitters.isEmpty()) {
-            log.debug("브로드캐스트할 SseEmitter가 없습니다: {}", eventName);
-            return;
-        }
-
-        log.debug("이벤트 브로드캐스트: {}, 대상 수: {}", eventName, emitters.size());
-
-        for (SseEmitter targetEmitter : emitters) {
-            try {
-                if (targetEmitter != null) {
-                    targetEmitter.send(SseEmitter.event()
-                            .name(SSE_EVENT_HEARTBEAT)
-                            .data(": heartbeat \n\n"));
-                }
-            } catch (IOException e) {
-                log.error("SSE 브로드캐스트 실패: {}", e.getMessage());
-                targetEmitter.completeWithError(e);
-            } catch (Exception e) {
-                log.error("SSE 브로드캐스트 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
-                targetEmitter.completeWithError(e);
-            }
-        }
     }
 }
 

--- a/morib/src/main/java/org/morib/server/global/sse/application/service/SseService.java
+++ b/morib/src/main/java/org/morib/server/global/sse/application/service/SseService.java
@@ -1,25 +1,15 @@
 package org.morib.server.global.sse.application.service;
 
 import lombok.RequiredArgsConstructor;
-import org.morib.server.domain.relationship.application.FetchRelationshipService;
-import org.morib.server.domain.relationship.infra.Relationship;
 import org.morib.server.global.exception.SSEConnectionException;
 import org.morib.server.global.message.ErrorMessage;
-import org.morib.server.global.sse.api.UserInfoDtoForSseUserInfoWrapper;
-import org.morib.server.global.sse.application.event.SseDisconnectEvent;
 import org.morib.server.global.sse.application.repository.SseRepository;
-import org.springframework.context.event.EventListener;
+import org.morib.server.global.sse.application.repository.SseUserInfoWrapper;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
-
-import static org.morib.server.global.common.Constants.SSE_EVENT_CONNECT;
 
 @Service
 @RequiredArgsConstructor
@@ -32,16 +22,14 @@ public class SseService {
     }
 
     public SseEmitter add(Long userId, SseEmitter emitter) {
-        return sseRepository.add(userId, emitter, 0, "", null);
+        return sseRepository.addSseEmitter(userId, emitter);
     }
 
-    public void saveSseUserInfo(Long userId, SseEmitter emitter, UserInfoDtoForSseUserInfoWrapper calculatedSseUserInfoWrapper) {
-        sseRepository.add(
-                userId,
-                emitter,
-                calculatedSseUserInfoWrapper.elapsedTime(),
-                calculatedSseUserInfoWrapper.runningCategoryName(),
-                calculatedSseUserInfoWrapper.taskId());
+    public void removeExistingEmitter(Long userId) {
+        sseRepository.removeExistingEmitter(userId);
+    }
+    public void saveSseUserInfoWrapper(Long userId, SseUserInfoWrapper calculatedSseUserInfoWrapper) {
+        sseRepository.mergeUserInfoWrapper(userId, calculatedSseUserInfoWrapper);
     }
 
     public List<SseEmitter> fetchConnectedSseEmittersById(List<Long> ids) {
@@ -58,8 +46,8 @@ public class SseService {
     // SseEmitter hashMap에 들어있는 친구들의 카테고리 이름 조회 (온라인인 친구만 조회됨)
     public String fetchFriendsRunningCategoryNameBySseEmitters(Long userId) {
         try {
-            if (SseRepository.emitters.containsKey(userId)) {
-                return SseRepository.emitters.get(userId).getRunningCategoryName();
+            if (sseRepository.getConnectedUserIds().contains(userId)) {
+                return sseRepository.getSseUserInfoWrapperById(userId).getRunningCategoryName();
             }
         } catch (SSEConnectionException e) {
             throw new SSEConnectionException(ErrorMessage.SSE_CONNECT_FAILED);


### PR DESCRIPTION
## 📍 Issue
- closes #163

## ✨ Key Changes
SSE 관련 버그 수정했습니다.

- SSE 객체와 UserInfo를 분리했습니다. 연결이 끊겨도 마지막 사용자 정보를 잃지 않도록 했습니다.
  ```java
  // 변경된 SseUserInfoWrapper
  public class SseUserInfoWrapper {
      private int elapsedTime;
      private String runningCategoryName;
      private Long taskId;
      private TimerStatus timerStatus;
      private LocalDateTime lastTimerStatusChangeTime;
  
  // SseRepository
  public static final ConcurrentHashMap<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
  public static final ConcurrentHashMap<Long, SseUserInfoWrapper> userInfos = new ConcurrentHashMap<>();
  ```

- 연결 시 이벤트의 동기 처리를 위해 iteration을 추가해 기존 연결이 제거되었는지 확인하고 이벤트를 발송하도록 변경했습니다.
  ```java
  // 기존 연결이 있으면 종료
  sseService.removeExistingEmitter(userId);
  SseEmitter createdEmitter = sseService.create();
  
  for (int i=0; i<10; i++) {
      if (!sseService.validateConnection(userId)) {
          // emitter 생성 후 저장
          sseService.add(userId, createdEmitter);
          break;
      }
      else {
          log.info("SseEmitter is already connected. Retry to connect ... count : {}", i);
          Thread.sleep(10);
      }
  }
  // 브로드캐스트
  return broadcastAllAfterCreated(userId, createdEmitter, SSE_EVENT_CONNECT);
  ```

- SSE 요청 시 클라이언트의 인코딩 이슈로 인해 refresh 로직에서 카테고리 이름을 요청 받지 않고 조회해서 등록하도록 변경했습니다.
  ```java
  // 전달받은 내용을 userInfos에 업데이트
  Category findCategory = fetchCategoryService.fetchByUserIdAndTaskId(userId, taskId);
  SseUserInfoWrapper updatedSseUserInfoWrapper = updateAndBuildSseUserInfoWrapperWhenRefreshOrRunTimer(userId, taskId, elapsedTime, findCategory.getName(), timerStatus);
  sseService.saveSseUserInfoWrapper(userId, updatedSseUserInfoWrapper);
  return updatedSseUserInfoWrapper;
  ```

- fetch join으로 여러번 DB를 호출하지 않고 스트림으로 변경했습니다.
  ```java
   // refresh 시에는 현재 실행중인 타이머 정보를 보내므로 elapsedTime을 sse userInfos에 그대로 저장 (timer.setElapsedTime)
  public SseUserInfoWrapper updateAndBuildSseUserInfoWrapperWhenRefreshOrRunTimer(Long userId, Long taskId, int elapsedTime, String runningCategoryName, TimerStatus timerStatus) {
      Category findCategory = fetchCategoryService.fetchByUserIdAndTaskId(userId, taskId);
      findCategory.getTasks().stream()
              .filter(task -> task.getId().equals(taskId))
              .findFirst()
              .flatMap(task -> task.getTimers().stream()
                      .filter(timer -> timer.getTargetDate().equals(LocalDate.now()))
                      .findFirst()).ifPresent(timer -> timerManager.setElapsedTime(timer, elapsedTime));
      return SseUserInfoWrapper.of(elapsedTime, runningCategoryName, taskId, timerStatus, LocalDateTime.now());
  }
  ```

- SSE 생명주기 관리를 점검했습니다. 불필요한 맵 삭제를 제외했습니다.
  ```java
    emitter.onCompletion(() -> {
                    log.info("onCompletion 콜백 - userId: {}, emitter: {}", userId, emitter);
                    eventPublisher.publishEvent(new SseDisconnectEvent(this, userId));
                    emitters.remove(userId, emitter);
                });
    
                emitter.onTimeout(() -> {
                    log.info("onTimeout 콜백 - userId: {}, emitter: {}", userId, emitter);
                    emitter.complete();
                });
    
                emitter.onError(e -> {
                    log.error("SseEmitter 오류 발생 - userId: {}, 오류: {}, emitter: {}", userId, e.getMessage(), emitter);
                    eventPublisher.publishEvent(new SseDisconnectEvent(this, userId));
                    emitter.completeWithError(e);
                });
   ```

## 💡 Test Result

- 재연결 시 connect -> completion 순서로 호출되던 이슈를 해결하여 정상적으로 작동하도록 했습니다.
<img width="938" alt="스크린샷 2025-03-22 15 50 10" src="https://github.com/user-attachments/assets/7c987517-1f76-4d90-9d12-9e66a370b25e" />

## 💬 To Reviewers
