### PR TITLE
Feat [#167] 할일 카드 수정 api 구현

### DIFF
--- a/morib/src/main/java/org/morib/server/api/homeView/controller/TaskController.java
+++ b/morib/src/main/java/org/morib/server/api/homeView/controller/TaskController.java
@@ -1,5 +1,6 @@
 package org.morib.server.api.homeView.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.morib.server.api.homeView.dto.CreateTaskRequestDto;
 import org.morib.server.api.homeView.facade.HomeViewFacade;
@@ -36,7 +37,7 @@ public class TaskController {
 
     @PatchMapping("/tasks/{taskId}")
     public ResponseEntity<BaseResponse<?>> update(@PathVariable Long taskId,
-                                                  @RequestBody CreateTaskRequestDto createTaskRequestDto) {
+                                                  @Valid @RequestBody CreateTaskRequestDto createTaskRequestDto) {
         homeViewFacade.update(taskId, createTaskRequestDto);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }

--- a/morib/src/main/java/org/morib/server/api/homeView/controller/TaskController.java
+++ b/morib/src/main/java/org/morib/server/api/homeView/controller/TaskController.java
@@ -20,7 +20,7 @@ public class TaskController {
     private final PrincipalHandler principalHandler;
 
     @PostMapping("/tasks/{categoryId}")
-    public ResponseEntity<BaseResponse<?>> createTask(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+    public ResponseEntity<BaseResponse<?>> create(@AuthenticationPrincipal CustomUserDetails customUserDetails,
                                                       @PathVariable Long categoryId,
                                                       @RequestBody CreateTaskRequestDto createTaskRequestDto) {
         Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
@@ -34,8 +34,15 @@ public class TaskController {
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 
+    @PatchMapping("/tasks/{taskId}")
+    public ResponseEntity<BaseResponse<?>> update(@PathVariable Long taskId,
+                                                  @RequestBody CreateTaskRequestDto createTaskRequestDto) {
+        homeViewFacade.update(taskId, createTaskRequestDto);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS);
+    }
+
     @DeleteMapping("/tasks/{taskId}")
-    public ResponseEntity<BaseResponse<?>> deleteTask(@PathVariable Long taskId) {
+    public ResponseEntity<BaseResponse<?>> delete(@PathVariable Long taskId) {
         homeViewFacade.deleteTask(taskId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }

--- a/morib/src/main/java/org/morib/server/api/homeView/controller/TaskController.java
+++ b/morib/src/main/java/org/morib/server/api/homeView/controller/TaskController.java
@@ -3,6 +3,7 @@ package org.morib.server.api.homeView.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.morib.server.api.homeView.dto.CreateTaskRequestDto;
+import org.morib.server.api.homeView.dto.UpdateTaskRequestDto;
 import org.morib.server.api.homeView.facade.HomeViewFacade;
 import org.morib.server.global.common.ApiResponseUtil;
 import org.morib.server.global.common.BaseResponse;
@@ -37,8 +38,8 @@ public class TaskController {
 
     @PatchMapping("/tasks/{taskId}")
     public ResponseEntity<BaseResponse<?>> update(@PathVariable Long taskId,
-                                                  @Valid @RequestBody CreateTaskRequestDto createTaskRequestDto) {
-        homeViewFacade.update(taskId, createTaskRequestDto);
+                                                  @Valid @RequestBody UpdateTaskRequestDto updateTaskRequestDto) {
+        homeViewFacade.update(taskId, updateTaskRequestDto);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 

--- a/morib/src/main/java/org/morib/server/api/homeView/dto/CreateTaskRequestDto.java
+++ b/morib/src/main/java/org/morib/server/api/homeView/dto/CreateTaskRequestDto.java
@@ -1,12 +1,13 @@
 package org.morib.server.api.homeView.dto;
 
+import jakarta.validation.constraints.NotNull;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
 
 public record CreateTaskRequestDto(
-        String name,
-        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
-        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+        @NotNull String name,
+        @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+        @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
 
 }

--- a/morib/src/main/java/org/morib/server/api/homeView/dto/CreateTaskRequestDto.java
+++ b/morib/src/main/java/org/morib/server/api/homeView/dto/CreateTaskRequestDto.java
@@ -8,6 +8,6 @@ import java.time.LocalDate;
 public record CreateTaskRequestDto(
         @NotNull String name,
         @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
-        @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
 
 }

--- a/morib/src/main/java/org/morib/server/api/homeView/dto/UpdateTaskRequestDto.java
+++ b/morib/src/main/java/org/morib/server/api/homeView/dto/UpdateTaskRequestDto.java
@@ -1,0 +1,13 @@
+package org.morib.server.api.homeView.dto;
+
+import jakarta.validation.constraints.NotNull;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+public record UpdateTaskRequestDto(
+        @NotNull String name,
+        @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+        @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+) {
+}

--- a/morib/src/main/java/org/morib/server/api/homeView/facade/HomeViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/homeView/facade/HomeViewFacade.java
@@ -93,6 +93,12 @@ public class HomeViewFacade {
     }
 
     @Transactional
+    public void update(Long taskId, CreateTaskRequestDto createTaskRequestDto) {
+        Task findTask = fetchTaskService.fetchById(taskId);
+        taskManager.updateTask(findTask, createTaskRequestDto.name(), createTaskRequestDto.startDate(), createTaskRequestDto.endDate());
+    }
+
+    @Transactional
     public void startTimer(Long userId, StartTimerRequestDto startTimerRequestDto, LocalDate targetDate) {
         // 사용자 조회 (한 번만)
         User findUser = fetchUserService.fetchByUserId(userId);

--- a/morib/src/main/java/org/morib/server/api/homeView/facade/HomeViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/homeView/facade/HomeViewFacade.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.morib.server.annotation.Facade;
 import org.morib.server.api.homeView.dto.CreateTaskRequestDto;
 import org.morib.server.api.homeView.dto.StartTimerRequestDto;
+import org.morib.server.api.homeView.dto.UpdateTaskRequestDto;
 import org.morib.server.api.homeView.dto.fetch.FetchMyElapsedTimeResponseDto;
 import org.morib.server.api.homeView.dto.fetch.HomeViewRequestDto;
 import org.morib.server.api.homeView.dto.fetch.HomeViewResponseDto;
@@ -93,9 +94,9 @@ public class HomeViewFacade {
     }
 
     @Transactional
-    public void update(Long taskId, CreateTaskRequestDto createTaskRequestDto) {
+    public void update(Long taskId, UpdateTaskRequestDto updateTaskRequestDto) {
         Task findTask = fetchTaskService.fetchById(taskId);
-        taskManager.updateTask(findTask, createTaskRequestDto.name(), createTaskRequestDto.startDate(), createTaskRequestDto.endDate());
+        taskManager.updateTask(findTask, updateTaskRequestDto.name(), updateTaskRequestDto.startDate(), updateTaskRequestDto.endDate());
     }
 
     @Transactional

--- a/morib/src/main/java/org/morib/server/domain/task/TaskManager.java
+++ b/morib/src/main/java/org/morib/server/domain/task/TaskManager.java
@@ -4,10 +4,15 @@ import lombok.RequiredArgsConstructor;
 import org.morib.server.annotation.Manager;
 import org.morib.server.domain.task.infra.Task;
 
+import java.time.LocalDate;
+
 @RequiredArgsConstructor
 @Manager
 public class TaskManager {
     public void toggleTaskStatus(Task findTask) {
         findTask.toggleStatus();
+    }
+    public void updateTask(Task findTask, String name, LocalDate startDate, LocalDate endDate) {
+        findTask.updateName(name, startDate, endDate);
     }
 }

--- a/morib/src/main/java/org/morib/server/domain/task/infra/Task.java
+++ b/morib/src/main/java/org/morib/server/domain/task/infra/Task.java
@@ -50,4 +50,10 @@ public class Task extends BaseTimeEntity {
     public void toggleStatus() {
         this.isComplete = !this.isComplete;
     }
+
+    public void updateName(String name, LocalDate startDate, LocalDate endDate) {
+        this.name = name;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
 }


### PR DESCRIPTION
## 📍 Issue
- closes #167 

## ✨ Key Changes
## 할일 카드 수정 api 구현

### controller
날짜 또는 이름을 선택적으로 수정할 수 있도록 동시에 값을 받도록 했습니다.
`@Valid` + `@NotNull` 을 이용하여 값이 비어있지 않도록 했습니다.
https://github.com/morib-in/Morib-Server-v2/blob/50193f0c9baabf072a7b3c5a00f36ae1cf582d95/morib/src/main/java/org/morib/server/api/homeView/controller/TaskController.java#L39-L44
https://github.com/morib-in/Morib-Server-v2/blob/50193f0c9baabf072a7b3c5a00f36ae1cf582d95/morib/src/main/java/org/morib/server/api/homeView/dto/UpdateTaskRequestDto.java#L9-L11

### facade
taskManager를 이용해 조회해 온 Task를 업데이트합니다.
https://github.com/morib-in/Morib-Server-v2/blob/50193f0c9baabf072a7b3c5a00f36ae1cf582d95/morib/src/main/java/org/morib/server/api/homeView/facade/HomeViewFacade.java#L96-L100

### entity, manager
더티 체킹으로 엔티티를 업데이트합니다.
https://github.com/morib-in/Morib-Server-v2/blob/50193f0c9baabf072a7b3c5a00f36ae1cf582d95/morib/src/main/java/org/morib/server/domain/task/infra/Task.java#L54-L58
https://github.com/morib-in/Morib-Server-v2/blob/50193f0c9baabf072a7b3c5a00f36ae1cf582d95/morib/src/main/java/org/morib/server/domain/task/TaskManager.java#L16

## ✅ Test Result
<img width="1018" alt="스크린샷 2025-03-23 20 03 56" src="https://github.com/user-attachments/assets/67c0b963-066d-45af-8572-08795f07525b" />


## 💬 To Reviewers
