### PR TITLE
Refactor [#171] 타이머 하단 친구 목록 조회 필터링 추가

### DIFF
--- a/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
@@ -114,14 +114,11 @@ public class TimerViewFacade {
     public List<FetchRelationshipResponseDto> buildFetchRelationshipResponseDto(Long userId, List<Relationship> relationships) {
         return modalViewFacade.classifyRelationships(relationships, userId).values().stream()
                 .flatMap(List::stream)
-                .map(user -> FetchRelationshipResponseDto.of(
-                        user,
-                        healthCheckController.isUserActive(user.getId())
-                ))
-                .sorted(Comparator.comparing(FetchRelationshipResponseDto::isOnline).reversed())
+                .filter(user -> fetchTimerService.sumElapsedTimeByUser(user, LocalDate.now()) > 0)
+                .map(user -> FetchRelationshipResponseDto.of(user, healthCheckController.isUserActive(user.getId())))
+                .sorted(Comparator.comparing(FetchRelationshipResponseDto::isOnline).reversed().thenComparing(FetchRelationshipResponseDto::name))
                 .toList();
     }
-
 
     public void assignAllowedGroupsInTimer(Long userId, AssignAllowedGroupsRequestDto assignAllowedGroupsRequestDto) {
         List<Long> currentIdList = fetchRecentAllowedGroupService.findAllByUserId(userId).stream().map(recentAllowedGroup -> recentAllowedGroup.getSelectedAllowedGroup().getId()).toList();


### PR DESCRIPTION
## 📍 Issue
- closes #171 

## ✨ Key Changes

- 타이머 하단 친구 목록 조회 시, 필터링과 정렬 기준을 추가했습니다.
- 오늘 할일 몰입 시간이 0인 경우에는 `filter`를 사용해 제외했습니다.
- 온라인 -> 오프라인으로 정렬 후, `thenComparing`을 활용해 이름 오름차순으로 정렬했습니다.

https://github.com/morib-in/Morib-Server-v2/blob/660105bf7067efbab3162bec8e17d899c10f59f9/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java#L114-L121

## ✅ Test Result


## 💬 To Reviewers
