### PR TITLE
Refactor [#176] 온보딩 건너뛰기 및 예외 상황 처리

### DIFF
--- a/morib/src/main/java/org/morib/server/api/allowGroupView/controller/AllowedGroupViewController.java
+++ b/morib/src/main/java/org/morib/server/api/allowGroupView/controller/AllowedGroupViewController.java
@@ -109,8 +109,8 @@ public class AllowedGroupViewController {
     // 온보딩
     @PostMapping("/onboard")
     public ResponseEntity<BaseResponse<?>> onboard(@AuthenticationPrincipal CustomUserDetails customUserDetails,
-                                                   @RequestParam("interestArea") String interestArea,
-                                                   @RequestBody OnboardRequestDto onboardRequestDto) {
+                                                   @RequestParam(value = "interestArea", defaultValue = "unknown") String interestArea,
+                                                   @RequestBody(required = false) OnboardRequestDto onboardRequestDto) {
         Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
         allowedGroupViewFacade.onboard(userId, interestArea, onboardRequestDto);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);

--- a/morib/src/main/java/org/morib/server/api/allowGroupView/facade/AllowedGroupViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/allowGroupView/facade/AllowedGroupViewFacade.java
@@ -191,7 +191,7 @@ public class AllowedGroupViewFacade {
     public void onboard(Long userId, String interestArea, OnboardRequestDto onboardRequestDto) {
         User findUser = fetchUserService.fetchByUserId(userId);
         // 온보딩 완료 처리
-        findUser.completeOnboarding();
+        userManager.completeOnboarding(findUser);
         // 온보딩 건너뛰기를 누른 경우 (쿼리 파라미터가 비어있는 경우 OR 요청 Body가 비어있는 경우)
         // interestArea를 OTHERS로 설정
         if (interestArea.equals("unknown") || onboardRequestDto == null) {

--- a/morib/src/main/java/org/morib/server/api/allowGroupView/facade/AllowedGroupViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/allowGroupView/facade/AllowedGroupViewFacade.java
@@ -190,7 +190,6 @@ public class AllowedGroupViewFacade {
     @Transactional
     public void onboard(Long userId, String interestArea, OnboardRequestDto onboardRequestDto) {
         User findUser = fetchUserService.fetchByUserId(userId);
-        // 온보딩 완료 처리
         userManager.completeOnboarding(findUser);
         // 온보딩 건너뛰기를 누른 경우 (쿼리 파라미터가 비어있는 경우 OR 요청 Body가 비어있는 경우)
         // interestArea를 OTHERS로 설정

--- a/morib/src/main/java/org/morib/server/api/allowGroupView/facade/AllowedGroupViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/allowGroupView/facade/AllowedGroupViewFacade.java
@@ -190,6 +190,15 @@ public class AllowedGroupViewFacade {
     @Transactional
     public void onboard(Long userId, String interestArea, OnboardRequestDto onboardRequestDto) {
         User findUser = fetchUserService.fetchByUserId(userId);
+        // 온보딩 완료 처리
+        findUser.completeOnboarding();
+        // 온보딩 건너뛰기를 누른 경우 (쿼리 파라미터가 비어있는 경우 OR 요청 Body가 비어있는 경우)
+        // interestArea를 OTHERS로 설정
+        if (interestArea.equals("unknown") || onboardRequestDto == null) {
+            userManager.updateUserInterestArea(findUser, InterestArea.OTHERS.getInterestArea());
+            return;
+        }
+        // 온보딩을 정상적으로 진행하는 경우
         userManager.updateUserInterestArea(findUser, interestArea);
         AllowedGroup createdAllowedGroup = createAllowedGroupService.createWithBody(findUser, onboardRequestDto.name(), onboardRequestDto.colorCode());
         createAllowedSiteService.createAll(createdAllowedGroup, onboardRequestDto.allowedSiteVos());

--- a/morib/src/main/java/org/morib/server/domain/user/UserManager.java
+++ b/morib/src/main/java/org/morib/server/domain/user/UserManager.java
@@ -23,4 +23,8 @@ public class UserManager {
     public void updateUserInterestArea(User findUser, String interestArea) {
         findUser.updateUserInterestArea(InterestArea.fromValue(interestArea));
     }
+
+    public void completeOnboarding(User findUser) {
+        findUser.completeOnboarding();
+    }
 }

--- a/morib/src/main/java/org/morib/server/domain/user/infra/User.java
+++ b/morib/src/main/java/org/morib/server/domain/user/infra/User.java
@@ -49,6 +49,7 @@ public class User extends BaseTimeEntity {
     private String socialId; // 로그인한 소셜 타입의 식별자 값 (일반 로그인인 경우 null)
     private String social_refreshToken;
     private boolean isPushEnabled;
+    private boolean isOnboardingCompleted;
     // 유저 권한 설정 메소드
     public void authorizeUser() {
         this.role = Role.USER;
@@ -87,5 +88,9 @@ public class User extends BaseTimeEntity {
 
     public void updateUserInterestArea(InterestArea interestArea) {
         this.interestArea = interestArea;
+    }
+
+    public void completeOnboarding() {
+        this.isOnboardingCompleted = true;
     }
 }

--- a/morib/src/main/java/org/morib/server/global/common/Constants.java
+++ b/morib/src/main/java/org/morib/server/global/common/Constants.java
@@ -12,13 +12,14 @@ public final class Constants {
     public static final String ID_CLAIM = "id";
     public static final String SEND = "send";
     public static final String RECEIVE = "receive";
+    public static final String INVALID_REFRESH_TOKEN = "invalid";
+    public static final String GOOGLE_REVOKE_URL = "https://oauth2.googleapis.com/revoke";
+    public static final int MAX_VISIBLE_ALLOWED_SERVICES = 5;
+
+    // SSE 관련 상수들
     public static final Long SSE_TIMEOUT = 300_000L;
     public static final Long MAX_CONNECTION_TIME = 30 * 60 * 1000L;
     public static final int MAX_FAILED_ATTEMPTS = 100;
-    public static final String IS_ONBOARDING_COMPLETED = "?isOnboardingCompleted=";
-    public static final String GOOGLE_REGISTRATION_ID = "google";
-    public static final String INVALID_REFRESH_TOKEN = "invalid";
-    public static final String GOOGLE_REVOKE_URL = "https://oauth2.googleapis.com/revoke";
     public static final String SSE_EVENT_CONNECT = "connect";
     public static final String SSE_EVENT_COMPLETION = "completion";
     public static final String SSE_EVENT_REFRESH = "refresh";
@@ -28,7 +29,6 @@ public final class Constants {
     public static final String SSE_EVENT_FRIEND_REQUEST = "friendRequest";
     public static final String SSE_EVENT_FRIEND_REQUEST_ACCEPT = "friendRequestAccept";
     public static final String SSE_EVENT_HEARTBEAT = "heartbeat";
-    public static final int MAX_VISIBLE_ALLOWED_SERVICES = 5;
 
 
 }

--- a/morib/src/main/java/org/morib/server/global/common/Constants.java
+++ b/morib/src/main/java/org/morib/server/global/common/Constants.java
@@ -15,7 +15,7 @@ public final class Constants {
     public static final Long SSE_TIMEOUT = 300_000L;
     public static final Long MAX_CONNECTION_TIME = 30 * 60 * 1000L;
     public static final int MAX_FAILED_ATTEMPTS = 100;
-    public static final String IS_SIGN_UP_QUERYSTRING = "?isSignUp=";
+    public static final String IS_ONBOARDING_COMPLETED = "?isOnboardingCompleted=";
     public static final String GOOGLE_REGISTRATION_ID = "google";
     public static final String INVALID_REFRESH_TOKEN = "invalid";
     public static final String GOOGLE_REVOKE_URL = "https://oauth2.googleapis.com/revoke";

--- a/morib/src/main/java/org/morib/server/global/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/morib/src/main/java/org/morib/server/global/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -78,16 +78,16 @@ public class  OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler 
         log.info("3 : SocialRefreshToken Update");
         userManager.updateSocialRefreshToken(user, socialRefreshToken);
         StringBuilder redirectUri = new StringBuilder(secretProperties.getClientRedirectUriProd());
-
-        // dev
-//        StringBuilder redirectUri = new StringBuilder(secretProperties.getClientRedirectUriDev());
-
-        // common
-        redirectUri.append(IS_ONBOARDING_COMPLETED).append(isOnboardingCompleted);
+        String redirectUri = UriComponentsBuilder.fromUriString(secretProperties.getClientRedirectUriProd())
+                .queryParam(IS_ONBOARDING_COMPLETED, isOnboardingCompleted)
+                .queryParam(ACCESS_TOKEN_SUBJECT, accessToken)
+                .build()
+                .toUri()
+                .toString();
         redirectUri.append("&accessToken=").append(accessToken);
         log.info("redirectUri : " + redirectUri.toString());
         response.addCookie(dataUtils.getCookieForToken(REFRESH_TOKEN_SUBJECT, refreshToken));
-        log.info("Response Cookies: " + response.getHeaders("Set-Cookie"));
+        response.sendRedirect(redirectUri);
         response.sendRedirect(redirectUri.toString());
     }
 

--- a/morib/src/main/java/org/morib/server/global/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/morib/src/main/java/org/morib/server/global/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -42,7 +42,8 @@ public class  OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler 
     private final DataUtils dataUtils;
     private final FetchUserService fetchUserService;
     private final UserManager userManager;
-
+    private static final String IS_ONBOARDING_COMPLETED = "isOnboardingCompleted";
+    
     @Override
     @Transactional
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {


### PR DESCRIPTION
## 📍 Issue
- closes #176 

## ✨ Key Changes
온보딩 건너뛰기 및 이탈 시 처리하는 로직을 추가했어요.
<br>

### 온보딩을 정상적으로 진행하거나, 건너뛰기 처리(온보딩 완료)
해당 api에 들어왔다는 건, 온보딩 완료 처리를 의미하므로 유저를 DB에서 찾은 후 온보딩 완료 처리를 해주었어요.
- interestArea의 default value를 `unknown`으로 처리하고, 쿼리 파라미터가 비어있어 `unknown`이면 건너뛰기로 인식하게 했어요.
- 추가적인 예외 상황을 대비해, Request Body에 required=false 옵션을 넣어 비어있는 경우 건너뛰기로 인식하게 했어요.

https://github.com/morib-in/Morib-Server-v2/blob/389db014657c84a431dd87edcaa479d3644b0448/morib/src/main/java/org/morib/server/api/allowGroupView/facade/AllowedGroupViewFacade.java#L190-L205

<br>

### 로그인 성공 시에 온보딩 여부 redirect로 전달
기존에 로그인 여부로 온보딩 여부를 식별했는데, 이를 User DB에 추가하여 식별하도록 변경했어요. 
로그인 성공 시, 해당 유저의 값을 전달하여 온보딩을 진행할지 말지 클라이언트에서 인식하도록 했어요.

https://github.com/morib-in/Morib-Server-v2/blob/389db014657c84a431dd87edcaa479d3644b0448/morib/src/main/java/org/morib/server/global/oauth2/handler/OAuth2LoginSuccessHandler.java#L53-L59

## ✅ Test Result


## 💬 To Reviewers
