### PR TITLE
Fix [#179] 온보딩 내 URL로 사이트 가져오기 예외 핸들링

### DIFF
--- a/morib/src/main/java/org/morib/server/api/allowGroupView/controller/AllowedGroupViewController.java
+++ b/morib/src/main/java/org/morib/server/api/allowGroupView/controller/AllowedGroupViewController.java
@@ -117,8 +117,7 @@ public class AllowedGroupViewController {
     }
 
     @GetMapping("/onboard/allowedSite/info")
-    public ResponseEntity<BaseResponse<?>> fetchAllowedSiteInfoForOnboard(@AuthenticationPrincipal CustomUserDetails customUserDetails,
-                                                                          @RequestParam("siteUrl") String siteUrl) {
+    public ResponseEntity<BaseResponse<?>> fetchAllowedSiteInfoForOnboard(@RequestParam("siteUrl") String siteUrl) {
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, allowedGroupViewFacade.fetchAllowedSiteInfoForOnBoard(siteUrl));
     }
 

--- a/morib/src/main/java/org/morib/server/domain/allowedSite/application/FetchSiteInfoServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/allowedSite/application/FetchSiteInfoServiceImpl.java
@@ -90,7 +90,11 @@ public class FetchSiteInfoServiceImpl implements FetchSiteInfoService {
             InternetDomainName domainName = InternetDomainName.from(host);
             return domainName.topPrivateDomain().toString();
         } catch (Exception e) {
-            return urlString.split("://")[1].split("/")[0];
+            if (urlString.contains("://")) {
+                return urlString.split("://")[1].split("/")[0];
+            } else {
+                return urlString;
+            }
         }
     }
 

--- a/morib/src/main/java/org/morib/server/domain/allowedSite/application/FetchSiteInfoServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/allowedSite/application/FetchSiteInfoServiceImpl.java
@@ -90,7 +90,7 @@ public class FetchSiteInfoServiceImpl implements FetchSiteInfoService {
             InternetDomainName domainName = InternetDomainName.from(host);
             return domainName.topPrivateDomain().toString();
         } catch (Exception e) {
-            return urlString.split("//www.")[1].split("/")[0];
+            return urlString.split("://")[1].split("/")[0];
         }
     }
 


### PR DESCRIPTION
## 📍 Issue
- closes #179 

## ✨ Key Changes

### Split Regex 수정
`www` 로 시작하지 않는 url일 수도 있으므로 `://`로 구분자 지정해 해결했습니다. 

https://github.com/morib-in/Morib-Server-v2/blob/5eac83bd0af9a939facd90a09c0f577da52565bf/morib/src/main/java/org/morib/server/domain/allowedSite/application/FetchSiteInfoServiceImpl.java#L145

<br>

### 불필요한 인증 파라미터 제거
해당 API에서는 userId 파싱이 필요하지 않으므로 제거했습니다.

https://github.com/morib-in/Morib-Server-v2/blob/f8bb67ee15e9e60361d8e8db2d7547c31451be1a/morib/src/main/java/org/morib/server/api/allowGroupView/controller/AllowedGroupViewController.java#L120

## ✅ Test Result
<img width="1552" alt="스크린샷 2025-04-03 21 09 36" src="https://github.com/user-attachments/assets/74ba5f8a-85bc-4955-a326-10e4b16d895d" />


## 💬 To Reviewers
