### PR TITLE
Fix [#181] 타이머 정보 저장 시 Timer DB에 반영하는 방식 변경

### DIFF
--- a/morib/src/main/java/org/morib/server/api/allowGroupView/controller/AllowedGroupViewController.java
+++ b/morib/src/main/java/org/morib/server/api/allowGroupView/controller/AllowedGroupViewController.java
@@ -117,8 +117,7 @@ public class AllowedGroupViewController {
     }
 
     @GetMapping("/onboard/allowedSite/info")
-    public ResponseEntity<BaseResponse<?>> fetchAllowedSiteInfoForOnboard(@AuthenticationPrincipal CustomUserDetails customUserDetails,
-                                                                          @RequestParam("siteUrl") String siteUrl) {
+    public ResponseEntity<BaseResponse<?>> fetchAllowedSiteInfoForOnboard(@RequestParam("siteUrl") String siteUrl) {
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, allowedGroupViewFacade.fetchAllowedSiteInfoForOnBoard(siteUrl));
     }
 

--- a/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
@@ -65,7 +65,7 @@ public class TimerViewFacade {
         TimerSession findTimerSession = fetchTimerSessionService.fetchTimerSession(userId, saveTimerSessionRequestDto.targetDate());
         Category findCategory = fetchCategoryService.fetchByUserIdAndTaskId(userId, saveTimerSessionRequestDto.taskId());
         Timer findTimer = fetchTimerService.fetchByTaskIdAndTargetDate(saveTimerSessionRequestDto.taskId(), saveTimerSessionRequestDto.targetDate());
-        timerManager.addElapsedTime(findTimer, saveTimerSessionRequestDto.elapsedTime());
+        timerManager.setElapsedTime(findTimer, saveTimerSessionRequestDto.elapsedTime());
 
         if (findTimerSession == null) {
             createTimerSessionService.create(userId, findCategory.getName(), saveTimerSessionRequestDto.taskId(), saveTimerSessionRequestDto.elapsedTime(), saveTimerSessionRequestDto.timerStatus(), saveTimerSessionRequestDto.targetDate());

--- a/morib/src/main/java/org/morib/server/domain/allowedSite/application/FetchSiteInfoServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/allowedSite/application/FetchSiteInfoServiceImpl.java
@@ -90,7 +90,11 @@ public class FetchSiteInfoServiceImpl implements FetchSiteInfoService {
             InternetDomainName domainName = InternetDomainName.from(host);
             return domainName.topPrivateDomain().toString();
         } catch (Exception e) {
-            return urlString.split("://")[1].split("/")[0];
+            if (urlString.contains("://")) {
+                return urlString.split("://")[1].split("/")[0];
+            } else {
+                return urlString;
+            }
         }
     }
 

--- a/morib/src/main/java/org/morib/server/domain/allowedSite/application/FetchSiteInfoServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/allowedSite/application/FetchSiteInfoServiceImpl.java
@@ -90,7 +90,7 @@ public class FetchSiteInfoServiceImpl implements FetchSiteInfoService {
             InternetDomainName domainName = InternetDomainName.from(host);
             return domainName.topPrivateDomain().toString();
         } catch (Exception e) {
-            return urlString.split("//www.")[1].split("/")[0];
+            return urlString.split("://")[1].split("/")[0];
         }
     }
 


### PR DESCRIPTION
## 📍 Issue
- closes #181 

## ✨ Key Changes
타이머 정보 저장 시, ping과 sync api에서 addElapsedTime을 이용해 경과 시간을 더해주고 있었어요.
이를 로직의 간소화를 위해, 웹팀과 회의 후에 경과 시간이 아닌 현재 타이머의 시간을 요청받아 그대로 DB에 반영하도록 변경했어요.

https://github.com/morib-in/Morib-Server-v2/blob/8cbb35145dc19d44379cf59cccc9730c5e39c945/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java#L68

## ✅ Test Result


## 💬 To Reviewers
