### PR TITLE
Fix [#183] 유효하지 않은 URL 허용서비스 조회 시 에러 핸들링

### DIFF
--- a/morib/src/main/java/org/morib/server/annotation/ValidUrl.java
+++ b/morib/src/main/java/org/morib/server/annotation/ValidUrl.java
@@ -2,7 +2,7 @@ package org.morib.server.annotation;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
-import org.morib.server.global.common.UrlValidator;
+import org.morib.server.global.common.util.UrlValidator;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/morib/src/main/java/org/morib/server/api/allowGroupView/controller/AllowedGroupViewController.java
+++ b/morib/src/main/java/org/morib/server/api/allowGroupView/controller/AllowedGroupViewController.java
@@ -4,7 +4,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.morib.server.api.allowGroupView.dto.*;
 import org.morib.server.api.allowGroupView.facade.AllowedGroupViewFacade;
-import org.morib.server.global.common.ApiResponseUtil;
+import org.morib.server.global.common.util.ApiResponseUtil;
 import org.morib.server.global.common.BaseResponse;
 import org.morib.server.global.common.ConnectType;
 import org.morib.server.global.message.SuccessMessage;

--- a/morib/src/main/java/org/morib/server/api/homeView/controller/HomeViewController.java
+++ b/morib/src/main/java/org/morib/server/api/homeView/controller/HomeViewController.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.morib.server.api.homeView.dto.StartTimerRequestDto;
 import org.morib.server.api.homeView.dto.fetch.HomeViewRequestDto;
 import org.morib.server.api.homeView.facade.HomeViewFacade;
-import org.morib.server.global.common.ApiResponseUtil;
+import org.morib.server.global.common.util.ApiResponseUtil;
 import org.morib.server.global.common.BaseResponse;
 import org.morib.server.global.message.SuccessMessage;
 import org.morib.server.global.userauth.CustomUserDetails;

--- a/morib/src/main/java/org/morib/server/api/homeView/controller/TaskController.java
+++ b/morib/src/main/java/org/morib/server/api/homeView/controller/TaskController.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.morib.server.api.homeView.dto.CreateTaskRequestDto;
 import org.morib.server.api.homeView.dto.UpdateTaskRequestDto;
 import org.morib.server.api.homeView.facade.HomeViewFacade;
-import org.morib.server.global.common.ApiResponseUtil;
+import org.morib.server.global.common.util.ApiResponseUtil;
 import org.morib.server.global.common.BaseResponse;
 import org.morib.server.global.message.SuccessMessage;
 import org.morib.server.global.userauth.CustomUserDetails;

--- a/morib/src/main/java/org/morib/server/api/homeView/facade/HomeViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/homeView/facade/HomeViewFacade.java
@@ -27,7 +27,7 @@ import org.morib.server.domain.todo.application.FetchTodoService;
 import org.morib.server.domain.todo.infra.Todo;
 import org.morib.server.domain.user.application.service.FetchUserService;
 import org.morib.server.domain.user.infra.User;
-import org.morib.server.global.common.DataUtils;
+import org.morib.server.global.common.util.DataUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;

--- a/morib/src/main/java/org/morib/server/api/loginView/controller/UserAuthController.java
+++ b/morib/src/main/java/org/morib/server/api/loginView/controller/UserAuthController.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.morib.server.api.loginView.dto.UserReissueResponseDto;
 import org.morib.server.api.loginView.facade.UserAuthFacade;
 import org.morib.server.domain.user.application.dto.ReissueTokenServiceDto;
-import org.morib.server.global.common.ApiResponseUtil;
+import org.morib.server.global.common.util.ApiResponseUtil;
 import org.morib.server.global.common.BaseResponse;
 import org.morib.server.global.message.SuccessMessage;
 import org.morib.server.global.userauth.CustomUserDetails;

--- a/morib/src/main/java/org/morib/server/api/modalView/controller/CategoryController.java
+++ b/morib/src/main/java/org/morib/server/api/modalView/controller/CategoryController.java
@@ -3,7 +3,7 @@ package org.morib.server.api.modalView.controller;
 import lombok.RequiredArgsConstructor;
 import org.morib.server.api.modalView.dto.UpdateCategoryNameRequestDto;
 import org.morib.server.api.modalView.facade.ModalViewFacade;
-import org.morib.server.global.common.ApiResponseUtil;
+import org.morib.server.global.common.util.ApiResponseUtil;
 import org.morib.server.global.common.BaseResponse;
 import org.morib.server.global.message.SuccessMessage;
 import org.morib.server.global.userauth.CustomUserDetails;

--- a/morib/src/main/java/org/morib/server/api/modalView/controller/ModalViewController.java
+++ b/morib/src/main/java/org/morib/server/api/modalView/controller/ModalViewController.java
@@ -3,7 +3,7 @@ package org.morib.server.api.modalView.controller;
 import lombok.RequiredArgsConstructor;
 import org.morib.server.api.modalView.dto.CreateCategoryRequestDto;
 import org.morib.server.api.modalView.facade.ModalViewFacade;
-import org.morib.server.global.common.ApiResponseUtil;
+import org.morib.server.global.common.util.ApiResponseUtil;
 import org.morib.server.global.common.BaseResponse;
 import org.morib.server.global.message.SuccessMessage;
 import org.morib.server.global.userauth.CustomUserDetails;

--- a/morib/src/main/java/org/morib/server/api/modalView/controller/RelationshipController.java
+++ b/morib/src/main/java/org/morib/server/api/modalView/controller/RelationshipController.java
@@ -4,7 +4,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.morib.server.api.modalView.dto.CreateRelationshipRequestDto;
 import org.morib.server.api.modalView.facade.ModalViewFacade;
-import org.morib.server.global.common.ApiResponseUtil;
+import org.morib.server.global.common.util.ApiResponseUtil;
 import org.morib.server.global.common.BaseResponse;
 import org.morib.server.global.message.SuccessMessage;
 import org.morib.server.global.userauth.CustomUserDetails;

--- a/morib/src/main/java/org/morib/server/api/settingView/controller/SettingViewController.java
+++ b/morib/src/main/java/org/morib/server/api/settingView/controller/SettingViewController.java
@@ -3,7 +3,7 @@ package org.morib.server.api.settingView.controller;
 import lombok.RequiredArgsConstructor;
 import org.morib.server.api.settingView.dto.UpdateUserProfileRequestDto;
 import org.morib.server.api.settingView.facade.SettingViewFacade;
-import org.morib.server.global.common.ApiResponseUtil;
+import org.morib.server.global.common.util.ApiResponseUtil;
 import org.morib.server.global.common.BaseResponse;
 import org.morib.server.global.message.SuccessMessage;
 import org.morib.server.global.userauth.CustomUserDetails;

--- a/morib/src/main/java/org/morib/server/api/timerView/controller/TimerViewController.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/controller/TimerViewController.java
@@ -5,7 +5,7 @@ import org.morib.server.api.timerView.dto.AssignAllowedGroupsRequestDto;
 import org.morib.server.api.timerView.dto.SaveTimerSessionRequestDto;
 import org.morib.server.api.timerView.facade.TimerViewFacade;
 import org.morib.server.domain.timer.infra.TimerStatus;
-import org.morib.server.global.common.ApiResponseUtil;
+import org.morib.server.global.common.util.ApiResponseUtil;
 import org.morib.server.global.common.BaseResponse;
 import org.morib.server.global.message.SuccessMessage;
 import org.morib.server.global.userauth.CustomUserDetails;

--- a/morib/src/main/java/org/morib/server/domain/allowedSite/application/FetchSiteInfoServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/allowedSite/application/FetchSiteInfoServiceImpl.java
@@ -1,12 +1,10 @@
 package org.morib.server.domain.allowedSite.application;
 
-import com.google.common.net.InternetDomainName;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.morib.server.api.allowGroupView.dto.AllowedSiteVo;
-import org.morib.server.global.exception.InvalidURLException;
-import org.morib.server.global.message.ErrorMessage;
+import org.morib.server.global.common.util.UrlUtils;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -52,50 +50,24 @@ public class FetchSiteInfoServiceImpl implements FetchSiteInfoService {
             return AllowedSiteVo.of(favicon, siteName, pageName, url);
         }
         catch (IOException e) {
-            String domain = getTopDomainWhenParsingFailed(url);
+            String domain = UrlUtils.extractTopPrivateDomain(url);
             return AllowedSiteVo.of("", domain, domain, url);
         }
     }
 
     @Override
     public String getTopDomain(String urlString) {
-        try {
-            URL url = new URL(urlString);
-            String host = url.getHost();
-            InternetDomainName domainName = InternetDomainName.from(host);
-            return domainName.topPrivateDomain().toString();
-        } catch (Exception e) {
-            throw new InvalidURLException(ErrorMessage.INVALID_URL);
-        }
+        return UrlUtils.extractTopPrivateDomain(urlString);
     }
 
     @Override
     public String getTopDomainUrl(String urlString) {
-        try {
-            URL url = new URL(urlString);
-            String host = url.getHost();
-            InternetDomainName domainName = InternetDomainName.from(host);
-            String topPrivateDomain = domainName.topPrivateDomain().toString();
-            return url.getProtocol() + "://" + topPrivateDomain + "/";
-        } catch (Exception e) {
-            throw new InvalidURLException(ErrorMessage.INVALID_URL);
-        }
+        return UrlUtils.getTopDomainUrl(urlString);
     }
 
     @Override
     public String getTopDomainWhenParsingFailed(String urlString) {
-        try {
-            URL url = new URL(urlString);
-            String host = url.getHost();
-            InternetDomainName domainName = InternetDomainName.from(host);
-            return domainName.topPrivateDomain().toString();
-        } catch (Exception e) {
-            if (urlString.contains("://")) {
-                return urlString.split("://")[1].split("/")[0];
-            } else {
-                return urlString;
-            }
-        }
+        return UrlUtils.extractTopPrivateDomain(urlString);
     }
 
     @Override
@@ -140,13 +112,6 @@ public class FetchSiteInfoServiceImpl implements FetchSiteInfoService {
 
     @Override
     public String getDomainExceptHost(String urlString) {
-        try {
-            URL url = new URL(urlString);
-            String host = url.getHost();
-            InternetDomainName domainName = InternetDomainName.from(host);
-            return domainName.topPrivateDomain().toString();
-        } catch (Exception e) {
-            return urlString.split("//www.")[1].split("/")[0];
-        }
+        return UrlUtils.extractTopPrivateDomain(urlString);
     }
 }

--- a/morib/src/main/java/org/morib/server/global/common/HealthCheckController.java
+++ b/morib/src/main/java/org/morib/server/global/common/HealthCheckController.java
@@ -1,6 +1,7 @@
 package org.morib.server.global.common;
 
 import lombok.RequiredArgsConstructor;
+import org.morib.server.global.common.util.ApiResponseUtil;
 import org.morib.server.global.message.SuccessMessage;
 import org.morib.server.global.userauth.CustomUserDetails;
 import org.morib.server.global.userauth.PrincipalHandler;

--- a/morib/src/main/java/org/morib/server/global/common/util/ApiResponseUtil.java
+++ b/morib/src/main/java/org/morib/server/global/common/util/ApiResponseUtil.java
@@ -1,5 +1,6 @@
-package org.morib.server.global.common;
+package org.morib.server.global.common.util;
 
+import org.morib.server.global.common.BaseResponse;
 import org.morib.server.global.message.ErrorMessage;
 import org.morib.server.global.message.SuccessMessage;
 import org.springframework.http.ResponseEntity;

--- a/morib/src/main/java/org/morib/server/global/common/util/DataUtils.java
+++ b/morib/src/main/java/org/morib/server/global/common/util/DataUtils.java
@@ -1,4 +1,4 @@
-package org.morib.server.global.common;
+package org.morib.server.global.common.util;
 
 import jakarta.servlet.http.Cookie;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +29,12 @@ public class DataUtils {
                 cookie.getDomain(),
                 cookie.getPath());
         return cookie;
+    }
+
+    public static String extractDomainFromRawUrl(String urlString) {
+        if (urlString.contains("www.")) return urlString.split("www.")[1].split("/")[0];
+        else if (urlString.contains("://")) return urlString.split("://")[1].split("/")[0];
+        else return urlString;
     }
 }
 

--- a/morib/src/main/java/org/morib/server/global/common/util/UrlUtils.java
+++ b/morib/src/main/java/org/morib/server/global/common/util/UrlUtils.java
@@ -1,0 +1,131 @@
+package org.morib.server.global.common.util;
+
+import com.google.common.net.InternetDomainName;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class UrlUtils {
+
+    public static String extractTopPrivateDomain(String urlString) {
+        if (urlString == null || urlString.isBlank()) {
+            log.warn("입력된 URL 문자열이 null이거나 비어있습니다.");
+            return "";
+        }
+        try {
+            String urlWithProtocol = urlString;
+            if (!urlString.matches("^[a-zA-Z][a-zA-Z0-9+.-]*://.*")) {
+                urlWithProtocol = "http://" + urlString;
+            }
+
+            URL url = new URL(urlWithProtocol);
+            String host = url.getHost();
+
+            if (host == null || host.isBlank()) {
+                log.warn("URL에서 호스트를 추출할 수 없습니다: {}", urlString);
+                return extractDomainFromRawUrl(urlString);
+            }
+
+            if (host.matches("^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}$")) {
+                log.debug("입력된 호스트가 IP 주소 형식이므로 호스트 자체를 반환합니다: {}", host);
+                return host;
+            }
+
+            InternetDomainName domainName = InternetDomainName.from(host);
+            if (domainName.isTopPrivateDomain()) {
+                return domainName.toString();
+            } else if (domainName.hasParent()) {
+                return domainName.topPrivateDomain().toString();
+            } else {
+                log.warn("최상위 개인 도메인을 찾을 수 없습니다: {}", host);
+                return extractDomainFromRawUrl(urlString);
+            }
+        } catch (MalformedURLException e) {
+            log.warn("잘못된 형식의 URL입니다: {}, 기본 도메인 추출 시도 - {}", urlString, e.getMessage());
+            return extractDomainFromRawUrl(urlString);
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            log.warn("URL로부터 도메인 파싱 중 오류 발생: {}, 기본 도메인 추출 시도 - {}", urlString, e.getMessage());
+            return extractDomainFromRawUrl(urlString);
+        } catch (Exception e) {
+            log.error("도메인 추출 중 예상치 못한 오류 발생: {}", urlString, e);
+            return extractDomainFromRawUrl(urlString);
+        }
+    }
+
+    public static String getTopDomainUrl(String urlString) {
+        if (urlString == null || urlString.isBlank()) {
+            log.warn("입력된 URL 문자열이 null이거나 비어있습니다.");
+            return "";
+        }
+        try {
+            String topPrivateDomain = extractTopPrivateDomain(urlString);
+            if (topPrivateDomain.isEmpty() || topPrivateDomain.equals(extractDomainFromRawUrl(urlString))) {
+                return extractDomainFromRawUrl(urlString);
+            }
+
+            String urlWithProtocol = urlString;
+            if (!urlString.matches("^[a-zA-Z][a-zA-Z0-9+.-]*://.*")) {
+                urlWithProtocol = "http://" + urlString;
+            }
+            URL originalUrl = new URL(urlWithProtocol);
+            String protocol = originalUrl.getProtocol();
+
+            return protocol + "://" + topPrivateDomain + "/";
+
+        } catch (MalformedURLException e) {
+            log.warn("최상위 도메인 URL 생성 중 잘못된 형식의 URL 발생: {}, 기본 도메인 추출 시도 - {}", urlString, e.getMessage());
+            return extractDomainFromRawUrl(urlString);
+        } catch (Exception e) {
+            log.error("최상위 도메인 URL 생성 중 예상치 못한 오류 발생: {}", urlString, e);
+            return extractDomainFromRawUrl(urlString);
+        }
+    }
+
+    /**
+     * URL 파싱 실패 시 또는 기본적인 방법으로 URL 문자열에서 도메인 부분을 추출합니다.
+     * 예: "https://www.example.com/path" -> "example.com"
+     * 예: "http://example.co.uk/" -> "example.co.uk"
+     * 예: "example.com" -> "example.com"
+     *
+     * @param urlString 원본 URL 문자열
+     * @return 추출된 도메인 문자열, 실패 시 원본 문자열 반환 가능성 있음.
+     */
+    private static String extractDomainFromRawUrl(String urlString) {
+        if (urlString == null || urlString.isBlank()) {
+            return "";
+        }
+        String domain = urlString;
+        try {
+            // 프로토콜 제거 (존재하는 경우)
+            if (domain.contains("://")) {
+                domain = domain.split("://")[1];
+            }
+            // 경로 및 쿼리 파라미터 제거
+            if (domain.contains("/")) {
+                domain = domain.split("/")[0];
+            }
+            // 포트 번호 제거
+            if (domain.contains(":")) {
+                domain = domain.split(":")[0];
+            }
+            // 'www.' 제거 (존재하는 경우)
+            if (domain.startsWith("www.")) {
+                domain = domain.substring(4);
+            }
+            // 유효성 검사 추가 (간단히 . 포함 여부만 확인)
+            if (!domain.contains(".") || domain.startsWith(".") || domain.endsWith(".")){
+                log.warn("Raw URL에서 유효한 도메인 추출 실패: {}, 원본 반환 시도", urlString);
+                return urlString; // 유효하지 않다고 판단되면 원본 반환 (혹은 다른 처리)
+            }
+        } catch (Exception e) {
+            log.error("Raw URL에서 도메인 추출 중 오류 발생: {}, 원본 반환", urlString, e);
+            return urlString; // 예외 발생 시 안전하게 원본 반환
+        }
+        return domain;
+    }
+}

--- a/morib/src/main/java/org/morib/server/global/common/util/UrlValidator.java
+++ b/morib/src/main/java/org/morib/server/global/common/util/UrlValidator.java
@@ -1,4 +1,4 @@
-package org.morib.server.global.common;
+package org.morib.server.global.common.util;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;

--- a/morib/src/main/java/org/morib/server/global/exception/GlobalExceptionHandler.java
+++ b/morib/src/main/java/org/morib/server/global/exception/GlobalExceptionHandler.java
@@ -1,7 +1,7 @@
 package org.morib.server.global.exception;
 
 import lombok.extern.slf4j.Slf4j;
-import org.morib.server.global.common.ApiResponseUtil;
+import org.morib.server.global.common.util.ApiResponseUtil;
 import org.morib.server.global.common.BaseResponse;
 import org.morib.server.global.message.ErrorMessage;
 import org.springframework.http.ResponseEntity;

--- a/morib/src/main/java/org/morib/server/global/jwt/CustomJwtAuthenticationEntryPoint.java
+++ b/morib/src/main/java/org/morib/server/global/jwt/CustomJwtAuthenticationEntryPoint.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.morib.server.global.common.ApiResponseUtil;
+import org.morib.server.global.common.util.ApiResponseUtil;
 import org.morib.server.global.message.ErrorMessage;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;

--- a/morib/src/main/java/org/morib/server/global/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/morib/src/main/java/org/morib/server/global/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -11,7 +11,7 @@ import org.morib.server.domain.user.application.service.FetchUserService;
 import org.morib.server.domain.user.infra.User;
 import org.morib.server.domain.user.infra.UserRepository;
 import org.morib.server.domain.user.infra.type.Role;
-import org.morib.server.global.common.DataUtils;
+import org.morib.server.global.common.util.DataUtils;
 import org.morib.server.global.common.SecretProperties;
 import org.morib.server.global.exception.NotFoundException;
 import org.morib.server.global.exception.UnauthorizedException;


### PR DESCRIPTION
## 📍 Issue
- closes #183
## ✨ Key Changes

### 에러 핸들링
유효하지 않은 URL을 허용 서비스에 등록하고, 이를 조회할 때 도메인 이름을 파싱하게 되는데 해당 라이브러리에서 유효하지 않은 URL은 파싱할 수 없기 때문에 Exception이 발생했습니다. 
이에, 파싱이 불가한 URL의 경우 split을 통해 `www` 또는 프로토콜을 제외해 리턴하도록 변경했습니다. (개인 노션 계정이나 개발용 테스트 서버일 수도 있으므로)

https://github.com/morib-in/Morib-Server-v2/blob/f201a84cb31b3580a6ca34fee11afe8e338b977d/morib/src/main/java/org/morib/server/global/common/util/UrlUtils.java#L98-L131

<br>

### 유틸 클래스 분리
추가로, URL 관련 코드가 허용 서비스 비즈니스 로직에 중복되어 포함되어 있는 것을 발견해 `UrlUtils` 유틸 클래스로 분리했습니다.


## ✅ Test Result


## 💬 To Reviewers
