### PR TITLE
Fix [#185] 3차 QA 반영

### DIFF
--- a/morib/src/main/java/org/morib/server/api/allowGroupView/facade/AllowedGroupViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/allowGroupView/facade/AllowedGroupViewFacade.java
@@ -23,10 +23,7 @@ import org.morib.server.global.exception.DuplicateResourceException;
 import org.morib.server.global.message.ErrorMessage;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.TreeMap;
+import java.util.*;
 
 import static org.morib.server.global.common.Constants.MAX_VISIBLE_ALLOWED_SERVICES;
 

--- a/morib/src/main/java/org/morib/server/api/modalView/controller/ModalViewController.java
+++ b/morib/src/main/java/org/morib/server/api/modalView/controller/ModalViewController.java
@@ -1,5 +1,6 @@
 package org.morib.server.api.modalView.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.morib.server.api.modalView.dto.CreateCategoryRequestDto;
 import org.morib.server.api.modalView.facade.ModalViewFacade;
@@ -21,7 +22,7 @@ public class ModalViewController {
 
     @PostMapping("/categories")
     public ResponseEntity<BaseResponse<?>> create(@AuthenticationPrincipal CustomUserDetails customUserDetails,
-                                                  @RequestBody CreateCategoryRequestDto createCategoryRequestDto) {
+                                                  @Valid @RequestBody CreateCategoryRequestDto createCategoryRequestDto) {
         Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
         modalViewFacade.createCategory(userId, createCategoryRequestDto);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);

--- a/morib/src/main/java/org/morib/server/api/modalView/dto/CreateCategoryRequestDto.java
+++ b/morib/src/main/java/org/morib/server/api/modalView/dto/CreateCategoryRequestDto.java
@@ -1,5 +1,7 @@
 package org.morib.server.api.modalView.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record CreateCategoryRequestDto(
-        String name) {
+        @NotBlank  String name) {
 }

--- a/morib/src/main/java/org/morib/server/api/timerView/controller/TimerViewController.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/controller/TimerViewController.java
@@ -1,5 +1,6 @@
 package org.morib.server.api.timerView.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.morib.server.api.timerView.dto.AssignAllowedGroupsRequestDto;
 import org.morib.server.api.timerView.dto.SaveTimerSessionRequestDto;
@@ -27,7 +28,7 @@ public class TimerViewController {
 
     @PostMapping("/timer/sync")
     public ResponseEntity<BaseResponse<?>> saveTimerSession(@AuthenticationPrincipal CustomUserDetails customUserDetails,
-                                                            @RequestBody SaveTimerSessionRequestDto saveTimerSessionRequestDto) {
+                                                            @Valid @RequestBody SaveTimerSessionRequestDto saveTimerSessionRequestDto) {
         Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
         timerViewFacade.saveTimerSession(userId, saveTimerSessionRequestDto);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);

--- a/morib/src/main/java/org/morib/server/api/timerView/dto/SaveTimerSessionRequestDto.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/dto/SaveTimerSessionRequestDto.java
@@ -1,13 +1,18 @@
 package org.morib.server.api.timerView.dto;
 
+import jakarta.validation.constraints.NotNull;
 import org.morib.server.domain.timer.infra.TimerStatus;
 
 import java.time.LocalDate;
 
 public record SaveTimerSessionRequestDto(
+        @NotNull
         Long taskId,
+        @NotNull
         int elapsedTime,
+        @NotNull
         TimerStatus timerStatus,
+        @NotNull
         LocalDate targetDate
 ) {
     public static SaveTimerSessionRequestDto of(Long taskId, int elapsedTime, TimerStatus timerStatus, LocalDate targetDate) {

--- a/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
@@ -116,7 +116,9 @@ public class TimerViewFacade {
                 .flatMap(List::stream)
                 .filter(user -> fetchTimerService.sumElapsedTimeByUser(user, LocalDate.now()) > 0)
                 .map(user -> FetchRelationshipResponseDto.of(user, healthCheckController.isUserActive(user.getId())))
-                .sorted(Comparator.comparing(FetchRelationshipResponseDto::isOnline).reversed().thenComparing(FetchRelationshipResponseDto::name))
+                .sorted(Comparator.comparing(FetchRelationshipResponseDto::isOnline).reversed()
+                        .thenComparing(FetchRelationshipResponseDto::elapsedTime).reversed()
+                        .thenComparing(FetchRelationshipResponseDto::name))
                 .toList();
     }
 

--- a/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
@@ -102,7 +102,7 @@ public class TimerViewFacade {
                     }
                     else {
                         TimerSession timerSession = fetchTimerSessionService.fetchTimerSession(dto.id(), LocalDate.now());
-                        return FriendsInTimerResponseDto.of(dto, timerSession.getElapsedTime(), timerSession.getRunningCategoryName(), timerSession.getTimerStatus());
+                        return FriendsInTimerResponseDto.of(dto, dto.elapsedTime(), timerSession.getRunningCategoryName(), timerSession.getTimerStatus());
                     }
                 }).toList();
     }

--- a/morib/src/main/java/org/morib/server/global/common/util/DataUtils.java
+++ b/morib/src/main/java/org/morib/server/global/common/util/DataUtils.java
@@ -11,6 +11,7 @@ import java.time.LocalDate;
 @RequiredArgsConstructor
 @Component
 public class DataUtils {
+
     public static boolean isInRange(LocalDate idxDate, LocalDate startDate, LocalDate endDate) {
         return !idxDate.isBefore(startDate) && !idxDate.isAfter(endDate);
     }
@@ -29,12 +30,6 @@ public class DataUtils {
                 cookie.getDomain(),
                 cookie.getPath());
         return cookie;
-    }
-
-    public static String extractDomainFromRawUrl(String urlString) {
-        if (urlString.contains("www.")) return urlString.split("www.")[1].split("/")[0];
-        else if (urlString.contains("://")) return urlString.split("://")[1].split("/")[0];
-        else return urlString;
     }
 }
 

--- a/morib/src/main/java/org/morib/server/global/config/SecurityConfig.java
+++ b/morib/src/main/java/org/morib/server/global/config/SecurityConfig.java
@@ -54,8 +54,7 @@ public class SecurityConfig {
                 });
 
         http.authorizeHttpRequests((auth) -> auth
-                .requestMatchers("/","/css/**","/images/**","/js/**","/favicon.ico","/**").permitAll()
-                .requestMatchers("/api/v2/admin/sse/monitor", "/api/v2/admin/sse/gc").permitAll()
+                .requestMatchers("/","/css/**","/images/**","/js/**","/favicon.ico", "/profile", "/health").permitAll()
                 .anyRequest().authenticated()
         );
         http.addFilterAfter(jwtAuthenticationFilter(), LogoutFilter.class);

--- a/morib/src/main/java/org/morib/server/global/jwt/JwtAuthenticationFilter.java
+++ b/morib/src/main/java/org/morib/server/global/jwt/JwtAuthenticationFilter.java
@@ -49,9 +49,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 }
             }
             filterChain.doFilter(request, response);
-        } catch (AuthenticationException authenticationException) {
+        }
+        catch (NotFoundException notFoundException) {
             SecurityContextHolder.clearContext();
-            customJwtAuthenticationEntryPoint.commence(request, response, new BadCredentialsException(authenticationException.getMessage(), authenticationException));
+            customJwtAuthenticationEntryPoint.commence(request, response, new BadCredentialsException(ErrorMessage.NOT_FOUND.getMessage(), notFoundException));
+        }
+        catch (AuthenticationException authenticationException) {
+            SecurityContextHolder.clearContext();
+            customJwtAuthenticationEntryPoint.commence(request, response, new BadCredentialsException(ErrorMessage.UNAUTHORIZED.getMessage(), authenticationException));
         }
     }
 


### PR DESCRIPTION
## 📍 Issue
- closes #185 

## ✨ Key Changes
3차 QA 사항인 입력값 유효성 검사 강화, 친구 목록 정렬 로직 추가, 친구 몰입 시간 표시 기준 변경, 
그리고 인증 필터의 예외 처리 로직 개선을 진행했어요.

### 1. 카테고리 생성 시 이름 유효성 검사 추가
*   `categoryName` 필드에 `@NotBlank` 어노테이션을 추가하여, 이름이 비어 있거나 공백만 있는 경우 요청이 실패하도록 수정했어요.

    ```java
    public record CreateCategoryRequestDto(
        @NotBlank
        String categoryName
    )
    ```

### 2. 타이머 정보 저장 시 필드 유효성 검사 추가
*   타이머 정보 저장 API 요청 시, 필수 필드(`taskId`, `timerStatus`, `targetDate`, `elapsedTime`)에 `@NotNull` 어노테이션 검증을 추가했어요.

    ```java
    public record SaveTimerSessionRequestDto(
            @NotNull
            Long taskId,
            @NotNull
            int elapsedTime,
            @NotNull
            TimerStatus timerStatus,
            @NotNull
            LocalDate targetDate
    )
    ```

### 3. 타이머 하단 친구 목록 정렬 기준 추가
*   타이머 하단 친구 목록 조회 로직에 `elapsedTime` 기준 내림차순 정렬 조건을 추가했어요.
*   우선순위가 온/오프라인 -> 오늘 몰입 시간 내림차순 -> 이름 오름차순 으로 표시되도록 변경했어요.

    ```java
    public List<FetchRelationshipResponseDto> buildFetchRelationshipResponseDto(Long userId, List<Relationship> relationships) {
            return modalViewFacade.classifyRelationships(relationships, userId).values().stream()
                    .flatMap(List::stream)
                    .filter(user -> fetchTimerService.sumElapsedTimeByUser(user, LocalDate.now()) > 0)
                    .map(user -> FetchRelationshipResponseDto.of(user, healthCheckController.isUserActive(user.getId())))
                    .sorted(Comparator.comparing(FetchRelationshipResponseDto::isOnline).reversed()
                            .thenComparing(FetchRelationshipResponseDto::elapsedTime).reversed() // elapsedTime 내림차순 정렬 추가
                            .thenComparing(FetchRelationshipResponseDto::name))
                    .toList();
    }
    ```

### 4. 타이머 하단 친구 몰입 시간 표시 기준 변경
*   타이머 하단 친구 캐러셀에 표시되는 시간을 '오늘 몰입 시간'으로 변경했어요.
*   elapsedTime을 timerSession이 아닌 dto의 elapsedTime(현재 유저의 누적 몰입 시간)으로 변경했어요.

    ```java
    public List<FriendsInTimerResponseDto> fetchFriendsInfo(Long userId) {
            List<FetchRelationshipResponseDto> fetchRelationshipResponseDtoList = fetchConnectedRelationships(userId);
            return fetchRelationshipResponseDtoList.stream()
                    .map(dto -> {
                        if (fetchTimerSessionService.fetchTimerSession(dto.id(), LocalDate.now()) == null) {
                          return FriendsInTimerResponseDto.of(dto, 0, "", TimerStatus.PAUSED);
                        }
                        else {
                            TimerSession timerSession = fetchTimerSessionService.fetchTimerSession(dto.id(), LocalDate.now());
                            // elapsedTime을 timerSession이 아닌 dto의 elapsedTime(현재 유저의 누적 몰입 시간)으로 변경
                            return FriendsInTimerResponseDto.of(dto, dto.elapsedTime(), timerSession.getRunningCategoryName(), timerSession.getTimerStatus()); 
                        }
                    }).toList();
    }
    ```

### 5. 인증 필터(`JwtAuthenticationFilter`) 예외 처리 개선
*   예상치 못한 예외를 401로 처리하던 문제를 해결하기 위해 `JwtAuthenticationFilter`의 `catch` 블록을 수정했어요.
*   이제 인증 관련 예외만 필터에서 처리하고, 다른 예외는 전역 핸들러(`GlobalExceptionHandler`)로 넘겨서 올바른 상태 코드로 처리하도록 변경했어요.
*   이제 서비스 로직 오류 시 401 대신 500 같은 올바른 응답이 나가요.

    ```java
    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
            String requestUri = request.getRequestURI();
            if (requestUri.contains("reissue")) {
                jwtService.isTokenValidWhenReissueToken(request);
            }
    
            try {
                String accessToken = jwtService.extractAccessToken(request).orElse(null);
    
                if (accessToken != null) {
                    if (jwtService.isTokenValid(accessToken)) {
                        handleAccessToken(accessToken);
                    } else {
                        SecurityContextHolder.clearContext();
                        customJwtAuthenticationEntryPoint.commence(request, response, new BadCredentialsException(ErrorMessage.INVALID_TOKEN.getMessage()));
                        return;
                    }
                }
                filterChain.doFilter(request, response);
            } catch (AuthenticationException authenticationException) {
                SecurityContextHolder.clearContext();
                customJwtAuthenticationEntryPoint.commence(request, response, new BadCredentialsException(authenticationException.getMessage(), authenticationException));
            }
        }
    ```

### 6. 기타 리팩토링 및 정리
*   테스트용 필터 강제 허용 로직을 정리했어요. `267ef20`
*   유틸리티 함수를 `DataUtils`에서 `UrlUtils`로 이동했어요. `2661c14`


## ✅ Test Result


## 💬 To Reviewers
