### PR TITLE
Refactor [#189] 타이머 기능 전체 서버로 이관

### DIFF
--- a/morib/src/main/java/org/morib/server/annotation/IsToday.java
+++ b/morib/src/main/java/org/morib/server/annotation/IsToday.java
@@ -1,0 +1,21 @@
+package org.morib.server.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import org.morib.server.global.common.util.IsTodayValidator;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER}) // 필드와 파라미터에 적용 가능하도록 설정
+@Retention(RetentionPolicy.RUNTIME) // 런타임 시에 어노테이션 정보 유지
+@Constraint(validatedBy = IsTodayValidator.class) // 이 어노테이션의 유효성 검사를 수행할 Validator 클래스 지정
+public @interface IsToday {
+    String message() default "날짜는 오늘이어야 합니다."; // 유효성 검사 실패 시 기본 메시지
+
+    Class<?>[] groups() default {}; // 유효성 검사 그룹 지정 (기본값: 없음)
+
+    Class<? extends Payload>[] payload() default {}; // 유효성 검사 페이로드 지정 (기본값: 없음)
+}

--- a/morib/src/main/java/org/morib/server/api/homeView/controller/HomeViewController.java
+++ b/morib/src/main/java/org/morib/server/api/homeView/controller/HomeViewController.java
@@ -44,7 +44,7 @@ public class HomeViewController {
                                                       @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate,
                                                       @RequestBody StartTimerRequestDto startTimerRequestDto) {
         Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
-        homeViewFacade.startTimer(userId, startTimerRequestDto, targetDate);
+        homeViewFacade.enterTimer(userId, startTimerRequestDto, targetDate);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 

--- a/morib/src/main/java/org/morib/server/api/timerView/dto/TimerDtos.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/dto/TimerDtos.java
@@ -1,0 +1,34 @@
+package org.morib.server.api.timerView.dto;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import jakarta.validation.constraints.NotNull;
+import org.morib.server.annotation.IsToday;
+import org.morib.server.domain.timer.infra.TimerSession;
+import org.morib.server.domain.timer.infra.TimerStatus;
+
+public record TimerDtos() {
+
+    public record TimerRequest(@NotNull Long taskId, @NotNull @IsToday LocalDate targetDate) { }
+
+    public record TimerStatusResponse(
+            String runningCategoryName,
+            Long selectedTaskId,
+            int elapsedTime,
+            TimerStatus timerStatus,
+            LocalDate targetDate
+    ) {
+        public static TimerStatusResponse from(TimerSession timerSession) {
+            return new TimerStatusResponse(
+                    timerSession.getRunningCategoryName(),
+                    timerSession.getSelectedTask() != null ? timerSession.getSelectedTask().getId() : null,
+                    timerSession.getElapsedTime(),
+                    timerSession.getTimerStatus(),
+                    timerSession.getTargetDate()
+            );
+        }
+    }
+}

--- a/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
@@ -59,6 +59,15 @@ public class TimerViewFacade {
     private final TimerSessionManager timerSessionManager;
     private final HealthCheckController healthCheckController;
     private final TimerManager timerManager;
+    @Transactional
+    public void runTimer(Long userId, TimerDtos.TimerRequest requestDto) {
+        LocalDateTime now = LocalDateTime.now();
+        TimerSession findTimerSession = fetchTimerSessionService.fetchTimerSession(userId, requestDto.targetDate());
+        if (findTimerSession == null || !Objects.equals(findTimerSession.getSelectedTask().getId(), requestDto.taskId())) {
+            throw new NotFoundException(ErrorMessage.TIMER_SESSION_NOT_FOUND);
+        }
+        timerSessionManager.run(findTimerSession, now);
+    }
 
     @Transactional
     public void saveTimerSession(Long userId, SaveTimerSessionRequestDto saveTimerSessionRequestDto) {

--- a/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
@@ -108,6 +108,13 @@ public class TimerViewFacade {
     }
 
     @Transactional
+    public void handleHeartbeat(Long userId, LocalDate targetDate) {
+        LocalDateTime now = LocalDateTime.now();
+        TimerSession findTimerSession = fetchTimerSessionService.fetchTimerSession(userId, targetDate);
+        timerSessionManager.handleHeartbeat(findTimerSession, now);
+    }
+
+    @Transactional
     public TodoCardResponseDto fetchTodoCard(Long userId, LocalDate targetDate) {
         int totalTimeOfToday = fetchTimerService.sumElapsedTimeByUser(fetchUserService.fetchByUserId(userId), targetDate);
         Optional<Todo> todo = fetchTodoService.fetchByUserIdAndTargetDate(userId, targetDate);

--- a/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
@@ -97,6 +97,17 @@ public class TimerViewFacade {
     }
 
     @Transactional
+    public void selectTimerInfo(Long userId, TimerDtos.TimerRequest requestDto) {
+        User user = fetchUserService.fetchByUserId(userId);
+        Category findCategory = fetchCategoryService.fetchByUserIdAndTaskId(userId, requestDto.taskId());
+        Task selectedTask = fetchTaskService.fetchById(requestDto.taskId());
+        Timer timer = fetchTimerService.fetchOrCreateByTaskAndTargetDate(user, selectedTask, requestDto.targetDate());
+        TimerSession findTimerSession = fetchTimerSessionService.fetchTimerSession(userId, requestDto.targetDate());
+        if (findTimerSession == null) throw new NotFoundException(ErrorMessage.TIMER_SESSION_NOT_FOUND);
+        timerSessionManager.updateTimerSession(findTimerSession, findCategory.getName(), selectedTask, timer.getElapsedTime(), TimerStatus.PAUSED, requestDto.targetDate());
+    }
+
+    @Transactional
     public TodoCardResponseDto fetchTodoCard(Long userId, LocalDate targetDate) {
         int totalTimeOfToday = fetchTimerService.sumElapsedTimeByUser(fetchUserService.fetchByUserId(userId), targetDate);
         Optional<Todo> todo = fetchTodoService.fetchByUserIdAndTargetDate(userId, targetDate);

--- a/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
@@ -85,7 +85,7 @@ public class TimerViewFacade {
         }
         if (findTimerSession.getTimerStatus().equals(TimerStatus.PAUSED)) return;
 
-        int calculatedElapsedTime = calculateTimerSessionService.calculateElapsedTimeByLastCalculatedAt(findTimerSession, LocalDateTime.now());
+        int calculatedElapsedTime = calculateTimerSessionService.calculateElapsedTimeByLastCalculatedAt(findTimerSession, now);
         timerSessionManager.pause(calculatedElapsedTime, findTimerSession, now);
         timerManager.setElapsedTime(fetchTimerService.fetchByTaskIdAndTargetDate(requestDto.taskId(), requestDto.targetDate()), findTimerSession.getElapsedTime());
     }

--- a/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
@@ -22,6 +22,7 @@ import org.morib.server.domain.task.infra.Task;
 import org.morib.server.domain.timer.TimerManager;
 import org.morib.server.domain.timer.TimerSessionManager;
 import org.morib.server.domain.timer.application.FetchTimerService;
+import org.morib.server.domain.timer.application.TimerSession.CalculateTimerSessionService;
 import org.morib.server.domain.timer.application.TimerSession.CreateTimerSessionService;
 import org.morib.server.domain.timer.application.TimerSession.FetchTimerSessionService;
 import org.morib.server.domain.timer.infra.Timer;
@@ -32,9 +33,13 @@ import org.morib.server.domain.todo.infra.Todo;
 import org.morib.server.domain.user.application.service.FetchUserService;
 import org.morib.server.domain.user.infra.User;
 import org.morib.server.global.common.HealthCheckController;
+import org.morib.server.global.exception.NotFoundException;
+import org.morib.server.global.message.ErrorMessage;
+import org.springframework.cglib.core.Local;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -59,6 +64,8 @@ public class TimerViewFacade {
     private final TimerSessionManager timerSessionManager;
     private final HealthCheckController healthCheckController;
     private final TimerManager timerManager;
+    private final CalculateTimerSessionService calculateTimerSessionService;
+
     @Transactional
     public void runTimer(Long userId, TimerDtos.TimerRequest requestDto) {
         LocalDateTime now = LocalDateTime.now();
@@ -113,6 +120,24 @@ public class TimerViewFacade {
         TimerSession findTimerSession = fetchTimerSessionService.fetchTimerSession(userId, targetDate);
         timerSessionManager.handleHeartbeat(findTimerSession, now);
     }
+
+
+//
+
+    // ----------------------------------------------------------------------
+//    @Transactional
+//    public void saveTimerSession(Long userId, SaveTimerSessionRequestDto saveTimerSessionRequestDto) {
+//        TimerSession findTimerSession = fetchTimerSessionService.fetchTimerSession(userId, saveTimerSessionRequestDto.targetDate());
+//        Category findCategory = fetchCategoryService.fetchByUserIdAndTaskId(userId, saveTimerSessionRequestDto.taskId());
+//        Timer findTimer = fetchTimerService.fetchByTaskIdAndTargetDate(saveTimerSessionRequestDto.taskId(), saveTimerSessionRequestDto.targetDate());
+//        timerManager.setElapsedTime(findTimer, saveTimerSessionRequestDto.elapsedTime());
+//
+//        if (findTimerSession == null) {
+//            createTimerSessionService.create(userId, findCategory.getName(), saveTimerSessionRequestDto.taskId(), saveTimerSessionRequestDto.elapsedTime(), saveTimerSessionRequestDto.timerStatus(), saveTimerSessionRequestDto.targetDate());
+//        } else {
+//            timerSessionManager.updateTimerSession(findTimerSession, saveTimerSessionRequestDto);
+//        }
+//    }
 
     @Transactional
     public TodoCardResponseDto fetchTodoCard(Long userId, LocalDate targetDate) {

--- a/morib/src/main/java/org/morib/server/domain/timer/TimerManager.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/TimerManager.java
@@ -22,7 +22,6 @@ public class TimerManager {
         timer.setElapsedTime(elapsedTime);
     }
 
-
     public void addElapsedTime(Timer timer, int elapsedTime){
         timer.addElapsedTime(elapsedTime);
     }

--- a/morib/src/main/java/org/morib/server/domain/timer/TimerSessionManager.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/TimerSessionManager.java
@@ -14,4 +14,8 @@ public class TimerSessionManager {
     public void run(TimerSession timerSession, LocalDateTime now) {
         timerSession.run(now);
     }
+
+    public void pause(int calculatedElapsedTime, TimerSession timerSession, LocalDateTime now) {
+        timerSession.pause(calculatedElapsedTime, now);
+    }
 }

--- a/morib/src/main/java/org/morib/server/domain/timer/TimerSessionManager.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/TimerSessionManager.java
@@ -7,10 +7,10 @@ import org.morib.server.domain.timer.infra.TimerSession;
 @Manager
 public class TimerSessionManager {
 
-    public void updateTimerSession(TimerSession timerSession, SaveTimerSessionRequestDto saveTimerSessionRequestDto) {
-        timerSession.setElapsedTime(saveTimerSessionRequestDto.elapsedTime());
-        timerSession.setTimerStatus(saveTimerSessionRequestDto.timerStatus());
-        timerSession.setTaskId(saveTimerSessionRequestDto.taskId());
+    public void updateTimerSession(TimerSession timerSession, String runningCategoryName, Task selectedTask, int elapsedTime, TimerStatus timerStatus, LocalDate targetDate) {
+        timerSession.update(runningCategoryName, selectedTask, elapsedTime, timerStatus, targetDate);
+    }
+
     public void run(TimerSession timerSession, LocalDateTime now) {
         timerSession.run(now);
     }

--- a/morib/src/main/java/org/morib/server/domain/timer/TimerSessionManager.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/TimerSessionManager.java
@@ -11,6 +11,7 @@ public class TimerSessionManager {
         timerSession.setElapsedTime(saveTimerSessionRequestDto.elapsedTime());
         timerSession.setTimerStatus(saveTimerSessionRequestDto.timerStatus());
         timerSession.setTaskId(saveTimerSessionRequestDto.taskId());
-        timerSession.setTargetDate(saveTimerSessionRequestDto.targetDate());
+    public void run(TimerSession timerSession, LocalDateTime now) {
+        timerSession.run(now);
     }
 }

--- a/morib/src/main/java/org/morib/server/domain/timer/TimerSessionManager.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/TimerSessionManager.java
@@ -18,4 +18,8 @@ public class TimerSessionManager {
     public void pause(int calculatedElapsedTime, TimerSession timerSession, LocalDateTime now) {
         timerSession.pause(calculatedElapsedTime, now);
     }
+    public TimerSession handleCalledByClientFetch(int calculatedElapsedTime, TimerSession timerSession, LocalDateTime now) {
+        return timerSession.handleCalledByClientFetch(calculatedElapsedTime, now);
+    }
+
 }

--- a/morib/src/main/java/org/morib/server/domain/timer/TimerSessionManager.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/TimerSessionManager.java
@@ -2,7 +2,13 @@ package org.morib.server.domain.timer;
 
 import org.morib.server.annotation.Manager;
 import org.morib.server.api.timerView.dto.SaveTimerSessionRequestDto;
+import org.morib.server.domain.task.infra.Task;
 import org.morib.server.domain.timer.infra.TimerSession;
+import org.morib.server.domain.timer.infra.TimerStatus;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Manager
 public class TimerSessionManager {
@@ -18,6 +24,11 @@ public class TimerSessionManager {
     public void pause(int calculatedElapsedTime, TimerSession timerSession, LocalDateTime now) {
         timerSession.pause(calculatedElapsedTime, now);
     }
+
+    public void handleHeartbeat(TimerSession timerSession, LocalDateTime now) {
+        timerSession.updateHeartbeat(now);
+    }
+
     public TimerSession handleCalledByClientFetch(int calculatedElapsedTime, TimerSession timerSession, LocalDateTime now) {
         return timerSession.handleCalledByClientFetch(calculatedElapsedTime, now);
     }

--- a/morib/src/main/java/org/morib/server/domain/timer/application/FetchTimerService.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/application/FetchTimerService.java
@@ -16,6 +16,6 @@ public interface FetchTimerService {
     int sumElapsedTimeByUser(User user, LocalDate targetDate);
     Set<Long> fetchExistingTaskIdsByTargetDate(List<Task> tasks, LocalDate targetDate);
     Timer fetchByTaskIdAndTargetDate(Long taskId, LocalDate targetDate);
-
+    Timer fetchOrCreateByTaskAndTargetDate(User user, Task task, LocalDate targetDate);
 
 }

--- a/morib/src/main/java/org/morib/server/domain/timer/application/FetchTimerServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/application/FetchTimerServiceImpl.java
@@ -68,4 +68,13 @@ public class FetchTimerServiceImpl implements FetchTimerService{
         return timerRepository.findByTaskIdAndTargetDate(taskId, targetDate);
     }
 
+    @Override
+    public Timer fetchOrCreateByTaskAndTargetDate(User user, Task task, LocalDate targetDate) {
+        Timer timer = fetchByTaskAndTargetDate(task, targetDate);
+        if (timer == null) {
+            timer = Timer.create(user, targetDate, task);
+        }
+        return timer;
+    }
+
 }

--- a/morib/src/main/java/org/morib/server/domain/timer/application/TimerSession/CalculateTimerSessionService.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/application/TimerSession/CalculateTimerSessionService.java
@@ -1,0 +1,9 @@
+package org.morib.server.domain.timer.application.TimerSession;
+
+import org.morib.server.domain.timer.infra.TimerSession;
+
+import java.time.LocalDateTime;
+
+public interface CalculateTimerSessionService {
+    int calculateElapsedTimeByLastCalculatedAt(TimerSession timerSession, LocalDateTime now);
+}

--- a/morib/src/main/java/org/morib/server/domain/timer/application/TimerSession/CalculateTimerSessionServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/application/TimerSession/CalculateTimerSessionServiceImpl.java
@@ -1,0 +1,23 @@
+package org.morib.server.domain.timer.application.TimerSession;
+
+import lombok.RequiredArgsConstructor;
+import org.morib.server.domain.timer.infra.TimerSession;
+import org.morib.server.domain.timer.infra.TimerSessionRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class CalculateTimerSessionServiceImpl implements CalculateTimerSessionService {
+
+    private final TimerSessionRepository timerSessionRepository;
+
+    @Override
+    public int calculateElapsedTimeByLastCalculatedAt(TimerSession timerSession, LocalDateTime now) {
+        Duration elapsedSinceLastStart = Duration.between(timerSession.getLastCalculatedAt(), now);
+        return (int)elapsedSinceLastStart.toSeconds();
+    }
+
+}

--- a/morib/src/main/java/org/morib/server/domain/timer/application/TimerSession/CreateTimerSessionService.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/application/TimerSession/CreateTimerSessionService.java
@@ -1,9 +1,11 @@
 package org.morib.server.domain.timer.application.TimerSession;
 
+import org.morib.server.domain.task.infra.Task;
+import org.morib.server.domain.timer.infra.TimerSession;
 import org.morib.server.domain.timer.infra.TimerStatus;
 
 import java.time.LocalDate;
 
 public interface CreateTimerSessionService {
-    void create(Long userId, String runningCategoryName, Long taskId, int elapsedTime, TimerStatus timerStatus, LocalDate targetDate);
+    TimerSession create(Long userId, String runningCategoryName, Task task, int elapsedTime, TimerStatus timerStatus, LocalDate targetDate);
 }

--- a/morib/src/main/java/org/morib/server/domain/timer/application/TimerSession/CreateTimerSessionServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/application/TimerSession/CreateTimerSessionServiceImpl.java
@@ -1,6 +1,7 @@
 package org.morib.server.domain.timer.application.TimerSession;
 
 import lombok.RequiredArgsConstructor;
+import org.morib.server.domain.task.infra.Task;
 import org.morib.server.domain.timer.infra.TimerSession;
 import org.morib.server.domain.timer.infra.TimerSessionRepository;
 import org.morib.server.domain.timer.infra.TimerStatus;
@@ -15,8 +16,8 @@ public class CreateTimerSessionServiceImpl implements CreateTimerSessionService 
     private final TimerSessionRepository timerSessionRepository;
 
     @Override
-    public void create(Long userId, String runningCategoryName, Long taskId, int elapsedTime, TimerStatus timerStatus, LocalDate targetDate) {
-        timerSessionRepository.save(
-                TimerSession.create(userId, runningCategoryName, taskId, elapsedTime, timerStatus, targetDate));
+    public TimerSession create(Long userId, String runningCategoryName, Task task, int elapsedTime, TimerStatus timerStatus, LocalDate targetDate) {
+        return timerSessionRepository.save(
+                TimerSession.create(userId, runningCategoryName, task, elapsedTime, timerStatus, targetDate));
     }
 }

--- a/morib/src/main/java/org/morib/server/domain/timer/application/TimerSession/FetchTimerSessionService.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/application/TimerSession/FetchTimerSessionService.java
@@ -2,8 +2,12 @@ package org.morib.server.domain.timer.application.TimerSession;
 
 import org.morib.server.domain.timer.infra.TimerSession;
 
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface FetchTimerSessionService {
     TimerSession fetchTimerSession(Long userId, LocalDate targetDate);
+    List<TimerSession> fetchExpiredTimerSessions(LocalDateTime targetDateTime);
 }

--- a/morib/src/main/java/org/morib/server/domain/timer/application/TimerSession/FetchTimerSessionServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/application/TimerSession/FetchTimerSessionServiceImpl.java
@@ -3,9 +3,13 @@ package org.morib.server.domain.timer.application.TimerSession;
 import lombok.RequiredArgsConstructor;
 import org.morib.server.domain.timer.infra.TimerSession;
 import org.morib.server.domain.timer.infra.TimerSessionRepository;
+import org.morib.server.domain.timer.infra.TimerStatus;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,4 +22,8 @@ public class FetchTimerSessionServiceImpl implements FetchTimerSessionService {
         return timerSessionRepository.findByUserIdAndTargetDate(userId, targetDate);
     }
 
+    @Override
+    public List<TimerSession> fetchExpiredTimerSessions(LocalDateTime targetDateTime) {
+        return timerSessionRepository.findByTimerStatusAndLastHeartbeatAtBefore(TimerStatus.RUNNING, targetDateTime);
+    }
 }

--- a/morib/src/main/java/org/morib/server/domain/timer/infra/TimerSession.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/infra/TimerSession.java
@@ -47,3 +47,7 @@ public class TimerSession extends BaseTimeEntity {
         this.lastCalculatedAt = now;
         this.lastHeartbeatAt = now;
     }
+    public void updateHeartbeat(LocalDateTime now) {
+        if (this.timerStatus != TimerStatus.RUNNING) return;
+        this.lastHeartbeatAt = now;
+    }

--- a/morib/src/main/java/org/morib/server/domain/timer/infra/TimerSession.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/infra/TimerSession.java
@@ -2,9 +2,11 @@ package org.morib.server.domain.timer.infra;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.morib.server.domain.task.infra.Task;
 import org.morib.server.global.common.BaseTimeEntity;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -12,6 +14,8 @@ import java.time.LocalDate;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "timer_session",
+        uniqueConstraints = {@UniqueConstraint(columnNames = {"user_id", "targetDate"})})
 public class TimerSession extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,33 +25,65 @@ public class TimerSession extends BaseTimeEntity {
     private Long userId;
     @Column(nullable = false)
     private String runningCategoryName;
-    @Column(nullable = false)
-    private Long taskId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "selected_task_id")
+    private Task selectedTask;
     @Column(nullable = false)
     private int elapsedTime;
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private TimerStatus timerStatus;
+    private TimerStatus timerStatus = TimerStatus.PAUSED;
     @Column(nullable = false)
-    LocalDate targetDate;
+    private LocalDate targetDate;
+    private LocalDateTime lastCalculatedAt;
+    private LocalDateTime lastHeartbeatAt;
 
-    public static TimerSession create(Long userId, String runningCategoryName, Long taskId, int elapsedTime, TimerStatus timerStatus, LocalDate targetDate) {
+    public static TimerSession create(Long userId, String runningCategoryName, Task selectedTask, int elapsedTime, TimerStatus timerStatus, LocalDate targetDate) {
         return TimerSession.builder()
                 .userId(userId)
                 .runningCategoryName(runningCategoryName)
-                .taskId(taskId)
+                .selectedTask(selectedTask)
                 .elapsedTime(elapsedTime)
                 .timerStatus(timerStatus)
                 .targetDate(targetDate)
                 .build();
     }
-}
+
     public void run(LocalDateTime now) {
         this.timerStatus = TimerStatus.RUNNING;
         this.lastCalculatedAt = now;
         this.lastHeartbeatAt = now;
     }
+
+    public void pause(int calculateElapsedTime, LocalDateTime now) {
+        if (this.timerStatus != TimerStatus.RUNNING || this.lastCalculatedAt == null) return; // 실행 중이 아닐 때 무시
+        this.elapsedTime += calculateElapsedTime;
+        this.timerStatus = TimerStatus.PAUSED;
+        this.lastCalculatedAt = now;
+        this.lastHeartbeatAt = now;
+    }
+
     public void updateHeartbeat(LocalDateTime now) {
         if (this.timerStatus != TimerStatus.RUNNING) return;
         this.lastHeartbeatAt = now;
     }
+
+    public void update(String runningCategoryName, Task selectedTask, int elapsedTime, TimerStatus timerStatus, LocalDate targetDate) {
+        this.runningCategoryName = runningCategoryName;
+        this.selectedTask = selectedTask;
+        this.elapsedTime = elapsedTime;
+        this.timerStatus = timerStatus;
+        this.targetDate = targetDate;
+        this.lastCalculatedAt = null;
+        this.lastHeartbeatAt = null;
+    }
+
+    public TimerSession handleCalledByClientFetch(int calculatedElapsedTime, LocalDateTime now) {
+        this.elapsedTime += calculatedElapsedTime;
+        this.lastCalculatedAt = now;
+        this.lastHeartbeatAt = now;
+        return this;
+    }
+
+}
+

--- a/morib/src/main/java/org/morib/server/domain/timer/infra/TimerSession.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/infra/TimerSession.java
@@ -42,3 +42,8 @@ public class TimerSession extends BaseTimeEntity {
                 .build();
     }
 }
+    public void run(LocalDateTime now) {
+        this.timerStatus = TimerStatus.RUNNING;
+        this.lastCalculatedAt = now;
+        this.lastHeartbeatAt = now;
+    }

--- a/morib/src/main/java/org/morib/server/domain/timer/infra/TimerSessionRepository.java
+++ b/morib/src/main/java/org/morib/server/domain/timer/infra/TimerSessionRepository.java
@@ -4,8 +4,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 public interface TimerSessionRepository extends JpaRepository<TimerSession, Long> {
     TimerSession findByUserIdAndTargetDate(Long userId, LocalDate targetDate);
+    List<TimerSession> findByTimerStatusAndLastHeartbeatAtBefore(TimerStatus timerStatus, LocalDateTime lastHeartbeatAt);
+    List<TimerSession> findByTimerStatus(TimerStatus timerStatus);
 }

--- a/morib/src/main/java/org/morib/server/domain/user/infra/User.java
+++ b/morib/src/main/java/org/morib/server/domain/user/infra/User.java
@@ -18,7 +18,7 @@ import static org.morib.server.global.common.Constants.INVALID_REFRESH_TOKEN;
 
 @Entity
 @Getter
-@Builder(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PUBLIC)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class User extends BaseTimeEntity {

--- a/morib/src/main/java/org/morib/server/global/common/util/IsTodayValidator.java
+++ b/morib/src/main/java/org/morib/server/global/common/util/IsTodayValidator.java
@@ -1,0 +1,24 @@
+package org.morib.server.global.common.util;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.morib.server.annotation.IsToday;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+public class IsTodayValidator implements ConstraintValidator<IsToday, LocalDate> {
+
+    @Override
+    public void initialize(IsToday constraintAnnotation) {
+        // 어노테이션 초기화 (필요한 경우 로직 추가)
+    }
+
+    @Override
+    public boolean isValid(LocalDate value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        return Objects.equals(value, LocalDate.now());
+    }
+}

--- a/morib/src/main/java/org/morib/server/global/config/SecurityConfig.java
+++ b/morib/src/main/java/org/morib/server/global/config/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
                 });
 
         http.authorizeHttpRequests((auth) -> auth
-                .requestMatchers("/","/css/**","/images/**","/js/**","/favicon.ico", "/profile", "/health,", "/actuator/health").permitAll()
+                .requestMatchers("/","/css/**","/images/**","/js/**","/favicon.ico", "/profile", "/health,", "/actuator/**", "/error").permitAll()
                 .anyRequest().authenticated()
         );
         http.addFilterAfter(jwtAuthenticationFilter(), LogoutFilter.class);

--- a/morib/src/main/java/org/morib/server/global/jwt/JwtAuthenticationFilter.java
+++ b/morib/src/main/java/org/morib/server/global/jwt/JwtAuthenticationFilter.java
@@ -36,28 +36,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             jwtService.isTokenValidWhenReissueToken(request);
         }
 
-        try {
-            String accessToken = jwtService.extractAccessToken(request).orElse(null);
+        String accessToken = jwtService.extractAccessToken(request).orElse(null);
 
-            if (accessToken != null) {
-                if (jwtService.isTokenValid(accessToken)) {
-                    handleAccessToken(accessToken);
-                } else {
-                    SecurityContextHolder.clearContext();
-                    customJwtAuthenticationEntryPoint.commence(request, response, new BadCredentialsException(ErrorMessage.INVALID_TOKEN.getMessage()));
-                    return;
-                }
+        if (accessToken != null) {
+            if (jwtService.isTokenValid(accessToken)) {
+                handleAccessToken(accessToken);
+            } else {
+                SecurityContextHolder.clearContext();
+                customJwtAuthenticationEntryPoint.commence(request, response, new BadCredentialsException(ErrorMessage.INVALID_TOKEN.getMessage()));
+                return;
             }
-            filterChain.doFilter(request, response);
         }
-        catch (NotFoundException notFoundException) {
-            SecurityContextHolder.clearContext();
-            customJwtAuthenticationEntryPoint.commence(request, response, new BadCredentialsException(ErrorMessage.NOT_FOUND.getMessage(), notFoundException));
-        }
-        catch (AuthenticationException authenticationException) {
-            SecurityContextHolder.clearContext();
-            customJwtAuthenticationEntryPoint.commence(request, response, new BadCredentialsException(ErrorMessage.UNAUTHORIZED.getMessage(), authenticationException));
-        }
+        filterChain.doFilter(request, response);
     }
 
     private void handleAccessToken(String accessToken) throws NotFoundException {

--- a/morib/src/main/java/org/morib/server/global/message/ErrorMessage.java
+++ b/morib/src/main/java/org/morib/server/global/message/ErrorMessage.java
@@ -1,6 +1,7 @@
 package org.morib.server.global.message;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,6 +19,9 @@ public enum ErrorMessage {
     INVALID_TASK_IN_TODO(HttpStatus.BAD_REQUEST, "완료된 태스크는 할 일에 추가하거나 타이머를 실행할 수 없습니다."),
     CANNOT_ADD_YOURSELF(HttpStatus.BAD_REQUEST, "자기 자신을 친구로 추가할 수 없습니다."),
     WITHOUT_TIMER_STATUS(HttpStatus.BAD_REQUEST, "timerStatus 값이 없습니다. Request Header에 추가했는지 확인해주세요."),
+    TIMER_SESSION_NOT_FOUND(HttpStatus.BAD_REQUEST, "타이머 세션을 찾을 수 없습니다."),
+    MISSING_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "필수 요청 파라미터가 누락되었습니다."),
+    TARGET_DATE_IS_NOT_PRESENT(HttpStatus.BAD_REQUEST, "targetDate 날짜는 오늘이어야 합니다."),
     /**
      * 401 Unauthorized
      */
@@ -56,5 +60,4 @@ public enum ErrorMessage {
 
     private final HttpStatus httpStatus;
     private final String message;
-
 }

--- a/morib/src/main/java/org/morib/server/scheduler/TimerScheduler.java
+++ b/morib/src/main/java/org/morib/server/scheduler/TimerScheduler.java
@@ -1,0 +1,134 @@
+package org.morib.server.scheduler;
+
+import org.morib.server.domain.timer.TimerManager;
+import org.morib.server.domain.timer.application.TimerSession.FetchTimerSessionService;
+import org.morib.server.domain.timer.infra.TimerSessionRepository;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.morib.server.domain.task.infra.Task;
+import org.morib.server.domain.timer.application.FetchTimerService;
+import org.morib.server.domain.timer.infra.Timer;
+import org.morib.server.domain.timer.infra.TimerSession;
+import org.morib.server.domain.timer.infra.TimerStatus;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TimerScheduler {
+
+    private final TimerSessionRepository timerSessionRepository;
+    private final FetchTimerService fetchTimerService;
+    private final TimerManager timerManager;
+    private final FetchTimerSessionService fetchTimerSessionService;
+
+    private static final Duration INACTIVITY_THRESHOLD = Duration.ofMinutes(2);
+
+    @Scheduled(fixedRate = 60_000L)
+    @Transactional
+    public void updateActiveAndPauseInactiveTimers() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDate today = LocalDate.now();
+        LocalDateTime cutoffTime = now.minus(INACTIVITY_THRESHOLD);
+
+        List<TimerSession> runningSessions = timerSessionRepository.findByTimerStatus(TimerStatus.RUNNING);
+
+        if (runningSessions.isEmpty()) return;
+
+        int updatedCount = 0;
+        int pausedCount = 0;
+
+        for (TimerSession session : runningSessions) {
+            try {
+                LocalDateTime lastCalculatedAt = session.getLastCalculatedAt();
+                LocalDateTime lastHeartbeatTime = session.getLastHeartbeatAt();
+
+                if (lastCalculatedAt == null) {
+                    log.error("[타이머 스케줄러] 오류: 실행 중인 세션 {}의 lastCalculatedAt(lastStartedAt)이 null입니다. PAUSED 처리합니다.", session.getId());
+                    session.setTimerStatus(TimerStatus.PAUSED);
+                    session.setLastHeartbeatAt(null);
+                    pausedCount++;
+                    continue;
+                }
+
+                boolean isInactive = (lastHeartbeatTime == null || lastHeartbeatTime.isBefore(cutoffTime));
+
+                if (isInactive) {
+                    // 비활성 세션의 경우, 마지막 계산 시점과 현재 시점 사이의 경과 시간을 계산
+                    Duration elapsedDuration = Duration.ZERO;
+                    if (lastHeartbeatTime != null) {
+                        elapsedDuration = Duration.between(lastCalculatedAt, now);
+                    } else {
+                        log.warn("[타이머 스케줄러] 비활성 세션 {}의 lastHeartbeatTime({})이 유효하지 않아 경과 시간 0으로 처리.", session.getId(), lastHeartbeatTime);
+                    }
+                    int deltaSeconds = (int) Math.max(0, elapsedDuration.toSeconds());
+
+                    updateElapsedTimeAndPause(session, deltaSeconds);
+                    pausedCount++;
+
+                } else {
+                    // 활성 세션의 경우, 마지막 계산 시점과 현재 시점 사이의 경과 시간을 계산
+                    Duration elapsedDuration = Duration.between(lastCalculatedAt, now);
+                    int deltaSeconds = (int) Math.max(0, elapsedDuration.toSeconds());
+
+                    updateElapsedTimeAndContinue(session, deltaSeconds, now, today);
+                    updatedCount++;
+                }
+
+            } catch (Exception e) {
+                log.error("[타이머 스케줄러] 세션 {} 처리 중 오류 발생: {}", session.getId(), e.getMessage(), e);
+            }
+        }
+        log.info("[타이머 스케줄러] 처리 완료. 활성 업데이트: {}건, 비활성 PAUSED: {}건", updatedCount, pausedCount);
+    }
+
+    // 비활성 세션의 경우 경과 시간을 업데이트하고 PAUSED 상태로 변경, 마지막 계산 시점과 마지막 하트비트 시점을 null로 설정
+    private void updateElapsedTimeAndPause(TimerSession session, int deltaSeconds) {
+        session.setElapsedTime(session.getElapsedTime() + deltaSeconds);
+        session.setTimerStatus(TimerStatus.PAUSED);
+        session.setLastCalculatedAt(null);
+        session.setLastHeartbeatAt(null);
+
+        updateTimerEntity(session.getSelectedTask(), session.getTargetDate(), deltaSeconds);
+
+        log.info("[타이머 스케줄러] 세션 {} PAUSED 처리 완료. 최종 경과 시간: {}", session.getId(), session.getElapsedTime());
+    }
+
+    // 활성 세션의 경우 경과 시간을 업데이트하고 RUNNING 상태로 유지, 마지막 계산 시점을 현재 시점으로 설정
+    private void updateElapsedTimeAndContinue(TimerSession session, int deltaSeconds, LocalDateTime calculationTime, LocalDate today) {
+        session.setElapsedTime(session.getElapsedTime() + deltaSeconds);
+        session.setLastCalculatedAt(calculationTime);
+
+        updateTimerEntity(session.getSelectedTask(), today, deltaSeconds);
+
+        log.info("[타이머 스케줄러] 세션 {} 시간 업데이트 완료. 누적 경과 시간: {}, 다음 계산 시작점: {}",
+                 session.getId(), session.getElapsedTime(), session.getLastCalculatedAt());
+    }
+
+    private void updateTimerEntity(Task task, LocalDate targetDate, int deltaSeconds) {
+        if (task == null) {
+            log.error("[타이머 스케줄러] Timer 업데이트 실패: 세션에 선택된 태스크가 없습니다.");
+            return;
+        }
+        if (deltaSeconds <= 0) {
+             log.info("[타이머 스케줄러] deltaSeconds가 0 이하이므로 Timer 업데이트를 건너뛰었습니다. Task: {}", task.getId());
+            return;
+        }
+
+        Timer timer = fetchTimerService.fetchByTaskIdAndTargetDate(task.getId(), targetDate);
+        if (timer != null) {
+            timerManager.addElapsedTime(timer, deltaSeconds);
+            log.info("[타이머 스케줄러] Task {}의 Timer {}에 {}초 추가됨. 최종 시간: {}", task.getId(), timer.getId(), deltaSeconds, timer.getElapsedTime());
+        } else {
+            log.error("[타이머 스케줄러] Timer 업데이트 실패: Task ID {} 날짜 {}에 해당하는 Timer 엔티티를 찾을 수 없습니다.", task.getId(), targetDate);
+        }
+    }
+}

--- a/morib/src/test/java/org/morib/server/facade/TimerFullScenarioIntegrationTest.java
+++ b/morib/src/test/java/org/morib/server/facade/TimerFullScenarioIntegrationTest.java
@@ -1,0 +1,266 @@
+package org.morib.server.facade; // 실제 프로젝트 경로로 수정
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.morib.server.api.homeView.dto.StartTimerRequestDto;
+import org.morib.server.api.homeView.facade.HomeViewFacade;
+import org.morib.server.api.timerView.dto.TimerDtos;
+import org.morib.server.api.timerView.facade.TimerViewFacade;
+import org.morib.server.domain.category.infra.Category;
+import org.morib.server.domain.category.infra.CategoryRepository;
+import org.morib.server.domain.task.infra.Task;
+import org.morib.server.domain.task.infra.TaskRepository;
+import org.morib.server.domain.timer.TimerManager;
+import org.morib.server.domain.timer.application.FetchTimerService;
+import org.morib.server.domain.timer.infra.*;
+import org.morib.server.domain.user.infra.User;
+import org.morib.server.domain.user.infra.UserRepository;
+import org.morib.server.domain.user.infra.type.Platform;
+import org.morib.server.scheduler.TimerScheduler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class TimerFullScenarioIntegrationTest {
+
+    // --- 의존성 주입 (이전과 동일) ---
+    @Autowired private HomeViewFacade homeViewFacade;
+    @Autowired private TimerViewFacade timerViewFacade;
+    @Autowired private TimerScheduler timerScheduler;
+    @Autowired private UserRepository userRepository;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private TaskRepository taskRepository;
+    @Autowired private TimerSessionRepository timerSessionRepository;
+    @Autowired private TimerRepository timerRepository;
+    @Autowired private FetchTimerService fetchTimerService;
+    @Autowired private EntityManager em;
+
+    // --- 테스트 데이터 (이전과 동일) ---
+    private User testUser;
+    private Category testCategory;
+    private Task task1, task2, task3;
+    private LocalDate targetDate;
+
+    @BeforeEach
+    void setUp() {
+        // ... (이전과 동일한 데이터 설정) ...
+        targetDate = LocalDate.now();
+        testUser = userRepository.save(User.builder().email("full@test.com").name("fulltester").platform(Platform.GOOGLE).isPushEnabled(false).isOnboardingCompleted(true).build());
+        testCategory = categoryRepository.save(Category.builder().user(testUser).name("Full Test Category").build());
+        task1 = taskRepository.save(Task.builder().category(testCategory).name("Task 1").startDate(targetDate).isComplete(false).build());
+        task2 = taskRepository.save(Task.builder().category(testCategory).name("Task 2").startDate(targetDate).isComplete(false).build());
+        task3 = taskRepository.save(Task.builder().category(testCategory).name("Inactive Task For Scheduler").startDate(targetDate).isComplete(false).build());
+
+        timerRepository.save(Timer.builder().user(testUser).task(task1).targetDate(targetDate).elapsedTime(0).build());
+        timerRepository.save(Timer.builder().user(testUser).task(task2).targetDate(targetDate).elapsedTime(0).build());
+        timerRepository.save(Timer.builder().user(testUser).task(task3).targetDate(targetDate).elapsedTime(0).build());
+
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("타이머 전체 시나리오 (진입, 시작, 하트비트, 선택, 동기화/조회, 시작, 정지, 스케줄러) 통합 테스트")
+    void timerFullScenarioTest() throws InterruptedException {
+        Long userId = testUser.getId();
+        LocalDateTime testStartTime = LocalDateTime.now();
+        targetDate = LocalDate.now();
+        // --- 시나리오 시작 ---
+
+        // [단계 0] 타이머 진입
+        System.out.println("\n[단계 0] 타이머 진입 (Task 1, 2, 3)");
+        // ... (enterTimer 호출 및 검증 0 - 이전과 동일) ...
+        List<Long> taskIdsToEnter = List.of(task1.getId(), task2.getId(), task3.getId());
+        StartTimerRequestDto enterRequest = new StartTimerRequestDto(taskIdsToEnter);
+        homeViewFacade.enterTimer(userId, enterRequest, targetDate);
+        TimerSession sessionAfterEnter = findTimerSession(userId, targetDate);
+        assertTimerSessionState(sessionAfterEnter, TimerStatus.PAUSED, task1.getId(), 0, "진입 후");
+
+        TimerDtos.TimerRequest selectRequest1 = new TimerDtos.TimerRequest(task1.getId(), targetDate);
+        timerViewFacade.selectTimerInfo(userId, selectRequest1); // Task 1 선택
+
+        TimerSession sessionAfterSelect1 = findTimerSession(userId, targetDate);
+        assertTimerSessionState(sessionAfterSelect1, TimerStatus.PAUSED, task1.getId(), 0, "Task 1 선택 후");
+        assertThat(sessionAfterSelect1.getLastCalculatedAt()).isNull(); // Pause 상태이므로 null
+        assertThat(sessionAfterSelect1.getLastHeartbeatAt()).isNull(); // Pause 상태이므로 null
+
+
+        // [단계 1] Task 1 시작
+        System.out.println("\n[단계 1] Task 1 시작");
+        // ... (runTimer 호출 및 검증 1 - 이전과 동일) ...
+        TimerDtos.TimerRequest runRequest1 = new TimerDtos.TimerRequest(task1.getId(), targetDate);
+        timerViewFacade.runTimer(userId, runRequest1);
+        LocalDateTime run1Time = LocalDateTime.now(); // 시작 시각 기록
+        TimerSession sessionAfterRun1 = findTimerSession(userId, targetDate);
+        assertTimerSessionState(sessionAfterRun1, TimerStatus.RUNNING, task1.getId(), 0, "Task 1 시작 후");
+
+        // [단계 2] Task 1 실행 중 - 하트비트
+        System.out.println("\n[단계 2] Task 1 실행 중 - 1초 후 하트비트");
+        // ... (handleHeartbeat 호출 및 검증 2 - 이전과 동일) ...
+        sleepSeconds(1); // 1초 대기
+        LocalDateTime heartbeat1Time = LocalDateTime.now();
+        timerViewFacade.handleHeartbeat(userId, targetDate);
+        TimerSession sessionAfterHeartbeat1 = findTimerSession(userId, targetDate);
+        assertTimerSessionState(sessionAfterHeartbeat1, TimerStatus.RUNNING, task1.getId(), 0, "하트비트 1 후"); // 시간은 아직 0
+        assertThat((int) Duration.between(sessionAfterHeartbeat1.getLastHeartbeatAt(), heartbeat1Time).toSeconds() < 1);
+
+
+        // [단계 3] Task 1 정지 (이전 단계 3에서 이동)
+        System.out.println("\n[단계 3] Task 1 실행 중 - 추가 1초 후 정지");
+        sleepSeconds(1); // 추가 1초 대기
+        LocalDateTime pause1Time = LocalDateTime.now();
+        TimerDtos.TimerRequest pauseRequest1 = new TimerDtos.TimerRequest(task1.getId(), targetDate);
+        timerViewFacade.pauseTimer(userId, pauseRequest1);
+
+        // 검증 3: Task 1 정지 후 상태
+        int deltaT1 = (int) Duration.between(run1Time, pause1Time).toSeconds(); // Task 1 실행 시간 (약 2초)
+        int expectedElapsedAfterPause1 = 0 + deltaT1;
+        TimerSession sessionAfterPause1 = findTimerSession(userId, targetDate);
+        assertTimerSessionState(sessionAfterPause1, TimerStatus.PAUSED, task1.getId(), expectedElapsedAfterPause1, "Task 1 정지 후");
+        assertTimerState(task1.getId(), targetDate, expectedElapsedAfterPause1, "Task 1 정지 후");
+
+
+        // --- 새로운 플로우 시작 ---
+
+        // [단계 4] Task 2 선택 (/timer/select)
+        System.out.println("\n[단계 4] Task 2 선택");
+        TimerDtos.TimerRequest selectRequest2 = new TimerDtos.TimerRequest(task2.getId(), targetDate);
+        timerViewFacade.selectTimerInfo(userId, selectRequest2); // Task 2 선택
+
+        // 검증 4: Task 2 선택 후 상태
+        TimerSession sessionAfterSelect2 = findTimerSession(userId, targetDate);
+        // selectTimerInfo는 선택된 Task만 바꾸고, 상태는 PAUSED, 시간은 *이전 Task의 최종 시간*을 유지한다고 가정
+        // (만약 Task 2 시간(0)으로 리셋한다면 expectedElapsedAfterPause1 -> 0 으로 변경 필요)
+        assertTimerSessionState(sessionAfterSelect2, TimerStatus.PAUSED, task2.getId(), 0, "Task 2 선택 후");
+        assertThat(sessionAfterSelect2.getLastCalculatedAt()).isNull(); // Pause 상태이므로 null
+        assertThat(sessionAfterSelect2.getLastHeartbeatAt()).isNull(); // Pause 상태이므로 null
+
+
+        // [단계 5] Task 2 조회 및 동기화 (/timer/sync)
+        System.out.println("\n[단계 5] Task 2 조회 및 동기화 (현재 PAUSED 상태)");
+        LocalDateTime sync2Time = LocalDateTime.now();
+        // PAUSED 상태에서 sync 호출 시, 시간 계산 없이 현재 상태만 반환해야 함
+        // lastSyncClientTime은 의미 없지만 형식상 전달 (예: 이전 pause 시간)
+
+        // [단계 6] Task 2 시작 (/timer/run)
+        System.out.println("\n[단계 6] Task 2 시작");
+        TimerDtos.TimerRequest runRequest2 = new TimerDtos.TimerRequest(task2.getId(), targetDate);
+        // runTimer는 선택된 Task (Task 2)의 Timer에서 elapsedTime(현재 0)을 가져와 세션에 설정해야 함
+        timerViewFacade.runTimer(userId, runRequest2);
+        LocalDateTime run2Time = LocalDateTime.now();
+
+        // 검증 6: Task 2 시작 후 상태
+        TimerSession sessionAfterRun2 = findTimerSession(userId, targetDate);
+        assertTimerSessionState(sessionAfterRun2, TimerStatus.RUNNING, task2.getId(), 0, "Task 2 시작 후"); // Task 2 시간(0)으로 리셋됨
+        assertThat((int) Duration.between(sessionAfterRun2.getLastHeartbeatAt(), run2Time).toSeconds() < 1);
+        assertThat((int) Duration.between(sessionAfterRun2.getLastHeartbeatAt(), run2Time).toSeconds() < 1);
+
+        sleepSeconds(2);
+        TimerDtos.TimerStatusResponse syncResponse2 = timerViewFacade.getSelectedTimerInfo(userId, targetDate);
+
+        // 검증 5: 동기화(조회) 후 상태 (변경 없어야 함)
+        assertThat(syncResponse2.timerStatus()).isEqualTo(TimerStatus.RUNNING);
+        assertThat(syncResponse2.selectedTaskId()).isEqualTo(task2.getId());
+        assertThat(syncResponse2.elapsedTime()).isEqualTo(2); // 이전 시간 그대로
+
+        TimerSession sessionAfterSync2 = findTimerSession(userId, targetDate);
+        assertTimerSessionState(sessionAfterSync2, TimerStatus.RUNNING, task2.getId(), 2, "Task 2 조회/동기화 후");
+
+
+
+        // [단계 7] Task 2 실행 중 - 정지 (/timer/pause)
+//        System.out.println("\n[단계 7] Task 2 실행 중 - 2초 후 정지");
+//        sleepSeconds(2); // 2초 대기
+//        LocalDateTime pause2Time = LocalDateTime.now();
+//        TimerDtos.TimerRequest pauseRequest2 = new TimerDtos.TimerRequest(task2.getId(), targetDate);
+//        timerViewFacade.pauseTimer(userId, pauseRequest2);
+//
+//        // 검증 7: Task 2 정지 후 상태
+//        int deltaT2 = (int) Duration.between(run2Time, pause2Time).toSeconds(); // Task 2 실행 시간 (약 2초)
+//        int expectedElapsedAfterPause2 = 0 + deltaT2; // Task 2 누적 시간
+//        TimerSession sessionAfterPause2 = findTimerSession(userId, targetDate);
+//        assertTimerSessionState(sessionAfterPause2, TimerStatus.PAUSED, task2.getId(), expectedElapsedAfterPause2, "Task 2 정지 후");
+//        assertTimerState(task1.getId(), targetDate, expectedElapsedAfterPause1, "Task 2 정지 후 Task 1"); // Task 1 시간 유지
+//        assertTimerState(task2.getId(), targetDate, expectedElapsedAfterPause2, "Task 2 정지 후 Task 2"); // Task 2 최종 시간
+
+
+        // [단계 8] 스케줄러 테스트 (이전 단계 7과 동일)
+        System.out.println("\n[단계 8] 비활성 세션(Task 3) 생성 및 스케줄러 테스트");
+        // ... (스케줄러 테스트 로직 - 이전과 동일) ...
+        LocalDateTime inactiveStartTime = LocalDateTime.now();
+        TimerDtos.TimerRequest selectRequest3 = new TimerDtos.TimerRequest(task3.getId(), targetDate);
+        timerViewFacade.selectTimerInfo(userId, selectRequest3);
+        TimerDtos.TimerRequest runRequest3 = new TimerDtos.TimerRequest(task3.getId(), targetDate);
+        timerViewFacade.runTimer(userId, runRequest3);
+        LocalDateTime run3Time = LocalDateTime.now();
+        System.out.println(" - 1분 30초 대기...");
+        sleepSeconds(90);
+        System.out.println(" - 스케줄러 실행 (활성 시간 업데이트)");
+        timerScheduler.updateActiveAndPauseInactiveTimers();
+        LocalDateTime schedulerRun1Time = LocalDateTime.now();
+        int deltaScheduler1 = (int) Duration.between(run3Time, schedulerRun1Time).toSeconds();
+        TimerSession sessionAfterScheduler1 = findTimerSession(userId, targetDate);
+        assertTimerSessionState(sessionAfterScheduler1, TimerStatus.RUNNING, task3.getId(), 0 + deltaScheduler1, "스케줄러 1차 실행 후");
+        assertTimerState(task3.getId(), targetDate, deltaScheduler1, "스케줄러 1차 실행 후 Task 3");
+        System.out.println(" - 추가 1분 대기...");
+        sleepSeconds(60);
+        System.out.println(" - 스케줄러 실행 (비활성 감지 및 PAUSE)");
+        timerScheduler.updateActiveAndPauseInactiveTimers();
+        LocalDateTime schedulerRun2Time = LocalDateTime.now();
+        int deltaScheduler2 = (int) Duration.between(schedulerRun1Time, schedulerRun2Time).toSeconds(); // heartbeat 없었으므로 delta 0 가정
+        int finalSchedulerElapsed = deltaScheduler1 + deltaScheduler2;
+        TimerSession sessionAfterScheduler2 = findTimerSession(userId, targetDate);
+        assertTimerSessionState(sessionAfterScheduler2, TimerStatus.PAUSED, task3.getId(), finalSchedulerElapsed, "스케줄러 2차 실행 후");
+        assertTimerState(task3.getId(), targetDate, finalSchedulerElapsed, "스케줄러 2차 실행 후 Task 3");
+
+
+        System.out.println("\n--- 시나리오 종료 ---");
+    }
+
+
+    // --- Helper Methods (이전과 동일) ---
+    private TimerSession findTimerSession(Long userId, LocalDate date) {
+        return timerSessionRepository.findByUserIdAndTargetDate(userId, date);
+    }
+
+    private Timer findTimer(Long taskId, LocalDate date) {
+        Timer timer = fetchTimerService.fetchByTaskIdAndTargetDate(taskId, date);
+        assertNotNull(timer, "Timer를 찾을 수 없습니다. TaskId: " + taskId + ", Date: " + date);
+        return timer;
+    }
+
+    private void assertTimerSessionState(TimerSession session, TimerStatus expectedStatus, Long expectedTaskId, int expectedElapsedTime, String context) {
+        System.out.println(" [" + context + "] 세션 검증: ID=" + session.getId() + ", 상태=" + session.getTimerStatus() + ", 선택Task=" + (session.getSelectedTask() != null ? session.getSelectedTask().getId() : "null") + ", 경과시간=" + session.getElapsedTime());
+        assertThat(session.getTimerStatus()).as("[" + context + "] 타이머 상태").isEqualTo(expectedStatus);
+        if (expectedTaskId != null) {
+            assertThat(session.getSelectedTask()).as("[" + context + "] 선택된 태스크").isNotNull();
+            assertThat(session.getSelectedTask().getId()).as("[" + context + "] 선택된 태스크 ID").isEqualTo(expectedTaskId);
+        } else {
+            assertThat(session.getSelectedTask()).as("[" + context + "] 선택된 태스크").isNull();
+        }
+        assertThat(session.getElapsedTime()).as("[" + context + "] 세션 경과 시간").isEqualTo(expectedElapsedTime);
+    }
+
+    private void assertTimerState(Long taskId, LocalDate date, int expectedElapsedTime, String context) {
+        Timer timer = findTimer(taskId, date);
+        System.out.println(" [" + context + "] Timer 검증: TaskID=" + taskId + ", 경과시간=" + timer.getElapsedTime());
+        assertThat(timer.getElapsedTime()).as("[" + context + "] Timer 경과 시간 (Task: " + taskId + ")").isEqualTo(expectedElapsedTime);
+    }
+
+    private void sleepSeconds(int seconds) throws InterruptedException {
+        Thread.sleep(seconds * 1000L);
+    }
+}

--- a/morib/src/test/java/org/morib/server/facade/TimerMultiUserIntegrationTest.java
+++ b/morib/src/test/java/org/morib/server/facade/TimerMultiUserIntegrationTest.java
@@ -1,0 +1,234 @@
+package org.morib.server.facade; // 실제 프로젝트 경로로 수정
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.morib.server.api.homeView.dto.StartTimerRequestDto;
+import org.morib.server.api.homeView.facade.HomeViewFacade;
+import org.morib.server.api.timerView.dto.TimerDtos;
+import org.morib.server.api.timerView.facade.TimerViewFacade;
+import org.morib.server.domain.category.infra.Category;
+import org.morib.server.domain.category.infra.CategoryRepository;
+import org.morib.server.domain.task.infra.Task;
+import org.morib.server.domain.task.infra.TaskRepository;
+import org.morib.server.domain.timer.TimerManager;
+import org.morib.server.domain.timer.application.FetchTimerService;
+import org.morib.server.domain.timer.infra.*;
+import org.morib.server.domain.user.infra.User;
+import org.morib.server.domain.user.infra.UserRepository;
+import org.morib.server.domain.user.infra.type.Platform;
+import org.morib.server.scheduler.TimerScheduler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@SpringBootTest
+@Transactional
+class TimerMultiUserIntegrationTest { // 클래스 이름 변경 또는 새 클래스 생성
+
+    // --- 의존성 주입 (동일) ---
+    @Autowired
+    private HomeViewFacade homeViewFacade;
+    @Autowired private TimerViewFacade timerViewFacade;
+    @Autowired private TimerScheduler timerScheduler;
+    @Autowired private UserRepository userRepository;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private TaskRepository taskRepository;
+    @Autowired private TimerSessionRepository timerSessionRepository;
+    @Autowired private TimerRepository timerRepository;
+    @Autowired private FetchTimerService fetchTimerService;
+    @Autowired private EntityManager em;
+
+    // --- 테스트 데이터 ---
+    private User testUser1, testUser2;
+    private Category testCategory1, testCategory2;
+    private Task task1_1, task1_2, task1_3; // User 1 tasks
+    private Task task2_1, task2_2;      // User 2 tasks
+    private LocalDate targetDate;
+
+    @BeforeEach
+    void setUp() {
+        targetDate = LocalDate.now();
+
+        // User 1 설정
+        testUser1 = userRepository.save(User.builder().email("user1@test.com").name("tester1").platform(Platform.GOOGLE).build());
+        testCategory1 = categoryRepository.save(Category.builder().user(testUser1).name("User1 Category").build());
+        task1_1 = taskRepository.save(Task.builder().category(testCategory1).name("Task 1-1").startDate(targetDate).isComplete(false).build());
+        task1_2 = taskRepository.save(Task.builder().category(testCategory1).name("Task 1-2").startDate(targetDate).isComplete(false).build());
+        task1_3 = taskRepository.save(Task.builder().category(testCategory1).name("Task 1-3 (Scheduler)").startDate(targetDate).isComplete(false).build());
+        timerRepository.save(Timer.builder().user(testUser1).task(task1_1).targetDate(targetDate).elapsedTime(0).build());
+        timerRepository.save(Timer.builder().user(testUser1).task(task1_2).targetDate(targetDate).elapsedTime(0).build());
+        timerRepository.save(Timer.builder().user(testUser1).task(task1_3).targetDate(targetDate).elapsedTime(0).build());
+
+        // User 2 설정
+        testUser2 = userRepository.save(User.builder().email("user2@test.com").name("tester2").platform(Platform.GOOGLE).build());
+        testCategory2 = categoryRepository.save(Category.builder().user(testUser2).name("User2 Category").build());
+        task2_1 = taskRepository.save(Task.builder().category(testCategory2).name("Task 2-1").startDate(targetDate).isComplete(false).build());
+        task2_2 = taskRepository.save(Task.builder().category(testCategory2).name("Task 2-2 (Scheduler)").startDate(targetDate).isComplete(false).build());
+        timerRepository.save(Timer.builder().user(testUser2).task(task2_1).targetDate(targetDate).elapsedTime(0).build());
+        timerRepository.save(Timer.builder().user(testUser2).task(task2_2).targetDate(targetDate).elapsedTime(0).build());
+
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("여러 사용자 타이머 시나리오 통합 테스트")
+    void multiUserTimerScenarioTest() throws InterruptedException {
+        Long userId1 = testUser1.getId();
+        Long userId2 = testUser2.getId();
+        targetDate = LocalDate.now(); // 필요 시 재설정
+
+        // --- 시나리오 시작 ---
+
+        // [단계 0] 각 사용자 타이머 진입
+        System.out.println("\n[단계 0] 사용자 1, 2 타이머 진입");
+        homeViewFacade.enterTimer(userId1, new StartTimerRequestDto(List.of(task1_1.getId(), task1_2.getId(), task1_3.getId())), targetDate);
+        homeViewFacade.enterTimer(userId2, new StartTimerRequestDto(List.of(task2_1.getId(), task2_2.getId())), targetDate);
+
+        TimerSession session1AfterEnter = findTimerSession(userId1, targetDate);
+        TimerSession session2AfterEnter = findTimerSession(userId2, targetDate);
+        assertTimerSessionState(session1AfterEnter, TimerStatus.PAUSED, task1_1.getId(), 0, "User 1 진입 후");
+        assertTimerSessionState(session2AfterEnter, TimerStatus.PAUSED, task2_1.getId(), 0, "User 2 진입 후");
+
+        // [단계 1] 각 사용자 Task 시작
+        System.out.println("\n[단계 1] 사용자 1 Task 1-1 시작, 사용자 2 Task 2-1 시작");
+        timerViewFacade.runTimer(userId1, new TimerDtos.TimerRequest(task1_1.getId(), targetDate));
+        LocalDateTime run1_1Time = LocalDateTime.now();
+        timerViewFacade.runTimer(userId2, new TimerDtos.TimerRequest(task2_1.getId(), targetDate));
+        LocalDateTime run2_1Time = LocalDateTime.now();
+
+        assertTimerSessionState(findTimerSession(userId1, targetDate), TimerStatus.RUNNING, task1_1.getId(), 0, "User 1 시작 후");
+        assertTimerSessionState(findTimerSession(userId2, targetDate), TimerStatus.RUNNING, task2_1.getId(), 0, "User 2 시작 후");
+
+        // [단계 2] 사용자 1 하트비트, 사용자 2 정지
+        System.out.println("\n[단계 2] 사용자 1 하트비트, 사용자 2 정지");
+        sleepSeconds(1);
+        timerViewFacade.handleHeartbeat(userId1, targetDate);
+        LocalDateTime pause2_1Time = LocalDateTime.now();
+        timerViewFacade.pauseTimer(userId2, new TimerDtos.TimerRequest(task2_1.getId(), targetDate));
+
+        int delta2_1 = (int) Duration.between(run2_1Time, pause2_1Time).toSeconds();
+        assertTimerSessionState(findTimerSession(userId1, targetDate), TimerStatus.RUNNING, task1_1.getId(), 0, "User 1 하트비트 후"); // 시간은 스케줄러나 다음 액션에서 계산됨
+        assertTimerSessionState(findTimerSession(userId2, targetDate), TimerStatus.PAUSED, task2_1.getId(), delta2_1, "User 2 정지 후");
+        assertTimerState(task2_1.getId(), targetDate, delta2_1, "User 2 정지 후");
+
+
+        // [단계 3] 사용자 1 정지, 사용자 2 Task 2-2 선택
+        System.out.println("\n[단계 3] 사용자 1 정지, 사용자 2 Task 2-2 선택");
+        sleepSeconds(1);
+        LocalDateTime pause1_1Time = LocalDateTime.now();
+        timerViewFacade.pauseTimer(userId1, new TimerDtos.TimerRequest(task1_1.getId(), targetDate));
+        timerViewFacade.selectTimerInfo(userId2, new TimerDtos.TimerRequest(task2_2.getId(), targetDate));
+
+        int delta1_1 = (int) Duration.between(run1_1Time, pause1_1Time).toSeconds(); // User 1의 Task 1-1 총 실행 시간 (약 2초)
+        assertTimerSessionState(findTimerSession(userId1, targetDate), TimerStatus.PAUSED, task1_1.getId(), delta1_1, "User 1 정지 후");
+        assertTimerState(task1_1.getId(), targetDate, delta1_1, "User 1 정지 후");
+        assertTimerSessionState(findTimerSession(userId2, targetDate), TimerStatus.PAUSED, task2_2.getId(), 0, "User 2 Task 2-2 선택 후"); // Task 2-2 시간(0)으로 리셋 가정
+
+        // [단계 4] 스케줄러 테스트 준비: 두 사용자 모두 다른 Task 실행
+        System.out.println("\n[단계 4] 스케줄러 테스트 준비: User 1 Task 1-3 시작, User 2 Task 2-2 시작");
+        timerViewFacade.selectTimerInfo(userId1, new TimerDtos.TimerRequest(task1_3.getId(), targetDate)); // User1 Task 1-3 선택
+        timerViewFacade.runTimer(userId1, new TimerDtos.TimerRequest(task1_3.getId(), targetDate));       // User1 Task 1-3 시작
+        LocalDateTime run1_3Time = LocalDateTime.now();
+        // User 2는 이미 Task 2-2가 선택된 상태
+        timerViewFacade.runTimer(userId2, new TimerDtos.TimerRequest(task2_2.getId(), targetDate));       // User2 Task 2-2 시작
+        LocalDateTime run2_2Time = LocalDateTime.now();
+
+        assertTimerSessionState(findTimerSession(userId1, targetDate), TimerStatus.RUNNING, task1_3.getId(), 0, "User 1 Task 1-3 시작 후");
+        assertTimerSessionState(findTimerSession(userId2, targetDate), TimerStatus.RUNNING, task2_2.getId(), 0, "User 2 Task 2-2 시작 후");
+
+        // [단계 5] 스케줄러 테스트 실행
+        System.out.println("\n[단계 5] 스케줄러 테스트 실행");
+        System.out.println(" - 1분 30초 대기...");
+        sleepSeconds(90); // 예시 시간, 실제 INACTIVITY_THRESHOLD 고려 필요
+
+        System.out.println(" - 스케줄러 실행 (활성 시간 업데이트)");
+        timerScheduler.updateActiveAndPauseInactiveTimers(); // 스케줄러 실행
+        LocalDateTime schedulerRun1Time = LocalDateTime.now();
+
+        // 검증 5-1: 스케줄러 1차 실행 후 (두 세션 모두 활성)
+        int deltaSched1_User1 = (int) Duration.between(run1_3Time, schedulerRun1Time).toSeconds();
+        int deltaSched1_User2 = (int) Duration.between(run2_2Time, schedulerRun1Time).toSeconds();
+
+        TimerSession session1AfterSched1 = findTimerSession(userId1, targetDate);
+        TimerSession session2AfterSched1 = findTimerSession(userId2, targetDate);
+        assertTimerSessionState(session1AfterSched1, TimerStatus.RUNNING, task1_3.getId(), 0 + deltaSched1_User1, "User 1 스케줄러 1차 후");
+        assertTimerState(task1_3.getId(), targetDate, deltaSched1_User1, "User 1 스케줄러 1차 후");
+        assertTimerSessionState(session2AfterSched1, TimerStatus.RUNNING, task2_2.getId(), 0 + deltaSched1_User2, "User 2 스케줄러 1차 후");
+        assertTimerState(task2_2.getId(), targetDate, deltaSched1_User2, "User 2 스케줄러 1차 후");
+
+
+        System.out.println(" - 추가 1분 대기 (비활성 유도)...");
+        sleepSeconds(60); // 비활성 유도 (INACTIVITY_THRESHOLD 초과 가정)
+
+        System.out.println(" - 스케줄러 실행 (비활성 감지 및 PAUSE)");
+        timerScheduler.updateActiveAndPauseInactiveTimers(); // 스케줄러 실행
+        LocalDateTime schedulerRun2Time = LocalDateTime.now(); // 비활성 Pause 시점 계산 위해 사용
+
+        // 검증 5-2: 스케줄러 2차 실행 후 (두 세션 모두 비활성 PAUSED)
+        // 비활성 시 시간 계산 정책에 따라 deltaScheduler2 계산 (여기선 0으로 가정, 실제 구현 확인 필요)
+        int finalSchedElapsed_User1 = (deltaSched1_User1) + (int) Duration.between(schedulerRun1Time, schedulerRun2Time).toSeconds();
+        int finalSchedElapsed_User2 = (deltaSched1_User2) + (int) Duration.between(schedulerRun1Time, schedulerRun2Time).toSeconds();
+
+        TimerSession session1AfterSched2 = findTimerSession(userId1, targetDate);
+        TimerSession session2AfterSched2 = findTimerSession(userId2, targetDate);
+        assertTimerSessionState(session1AfterSched2, TimerStatus.PAUSED, task1_3.getId(), finalSchedElapsed_User1, "User 1 스케줄러 2차 후");
+        assertTimerState(task1_3.getId(), targetDate, finalSchedElapsed_User1, "User 1 스케줄러 2차 후");
+        assertTimerSessionState(session2AfterSched2, TimerStatus.PAUSED, task2_2.getId(), finalSchedElapsed_User2, "User 2 스케줄러 2차 후");
+        assertTimerState(task2_2.getId(), targetDate, finalSchedElapsed_User2, "User 2 스케줄러 2차 후");
+
+
+        System.out.println("\n--- 시나리오 종료 ---");
+    }
+
+
+    // --- Helper Methods (이전과 동일, findTimerSession은 Optional 처리 권장) ---
+    private TimerSession findTimerSession(Long userId, LocalDate date) {
+        // Optional<TimerSession> sessionOpt = timerSessionRepository.findByUserIdAndTargetDate(userId, date);
+        // assertTrue(sessionOpt.isPresent(), "TimerSession을 찾을 수 없습니다. UserId: " + userId + ", Date: " + date);
+        // return sessionOpt.get();
+        // Optional 처리를 하거나, 테스트 데이터 생성을 보장한다면 바로 get() 사용 가능
+        return timerSessionRepository.findByUserIdAndTargetDate(userId, date);
+
+    }
+
+    private Timer findTimer(Long taskId, LocalDate date) {
+        Timer timer = fetchTimerService.fetchByTaskIdAndTargetDate(taskId, date);
+        assertNotNull(timer, "Timer를 찾을 수 없습니다. TaskId: " + taskId + ", Date: " + date);
+        return timer;
+    }
+
+    private void assertTimerSessionState(TimerSession session, TimerStatus expectedStatus, Long expectedTaskId, int expectedElapsedTime, String context) {
+        System.out.println(" [" + context + "] 세션 검증: UserID=" + session.getUserId() + ", SessionID=" + session.getId() + ", 상태=" + session.getTimerStatus() + ", 선택Task=" + (session.getSelectedTask() != null ? session.getSelectedTask().getId() : "null") + ", 경과시간=" + session.getElapsedTime());
+        assertThat(session.getTimerStatus()).as("[" + context + "] 타이머 상태").isEqualTo(expectedStatus);
+        if (expectedTaskId != null) {
+            assertThat(session.getSelectedTask()).as("[" + context + "] 선택된 태스크").isNotNull();
+            assertThat(session.getSelectedTask().getId()).as("[" + context + "] 선택된 태스크 ID").isEqualTo(expectedTaskId);
+        } else {
+            assertThat(session.getSelectedTask()).as("[" + context + "] 선택된 태스크").isNull();
+        }
+        assertThat(session.getElapsedTime()).as("[" + context + "] 세션 경과 시간").isEqualTo(expectedElapsedTime);
+    }
+
+    private void assertTimerState(Long taskId, LocalDate date, int expectedElapsedTime, String context) {
+        Timer timer = findTimer(taskId, date);
+        System.out.println(" [" + context + "] Timer 검증: TaskID=" + taskId + ", 경과시간=" + timer.getElapsedTime());
+        assertThat(timer.getElapsedTime()).as("[" + context + "] Timer 경과 시간 (Task: " + taskId + ")").isEqualTo(expectedElapsedTime);
+    }
+
+    private void sleepSeconds(int seconds) throws InterruptedException {
+        Thread.sleep(seconds * 1000L);
+    }
+}


### PR DESCRIPTION
## 📍 Issue
- closes #189 

## ✨ Key Changes
타이머 기능을 전면 서버로 이관했어요. [관련 위키](https://github.com/morib-in/Morib-Server-v2/wiki/%ED%83%80%EC%9D%B4%EB%A8%B8-%EB%8F%99%EC%9E%91-%EB%B0%A9%EC%8B%9D-%EA%B0%9C%EC%84%A0)

### 1. 할일 추가 후 타이머 진입 (homeview -> timerview)
- 할일 추가 후 타이머에 진입할 때 `TimerSession`이 없다면 생성하고, 가장 첫번째 할일이 자동으로 선택된 할일로 지정되도록 했어요. 
```java
Task firstTask = tasks.get(0);
Category findCategory = fetchCategoryService.fetchByUserIdAndTaskId(userId, firstTask.getId());
int elapsedTimeOfFirstTask = fetchTimerService.fetchElapsedTimeOrZeroByTaskAndTargetDate(firstTask, targetDate);
TimerSession findTimerSession = fetchTimerSessionService.fetchTimerSession(userId, targetDate);
if (findTimerSession == null) {
    createTimerSessionService.create(userId, findCategory.getName(), firstTask, elapsedTimeOfFirstTask, TimerStatus.PAUSED, targetDate);
} else {
    timerSessionManager.updateTimerSession(findTimerSession, findCategory.getName(), firstTask, elapsedTimeOfFirstTask, TimerStatus.PAUSED, targetDate);
}
```

### 2. 타이머 시작 
- 타이머 시작을 누르면, 타이머 세션을 조회하고 없거나 `taskId`가 일치하지 않으면 NFE를 발생시켜요. 이는, 할일 추가 후 타이머 시작 시에 타이머 세션을 무조건 생성하게 되어있기 때문에 이렇게 유효성 검사를 추가했어요.
- 타이머 정보가 저장되기 시작되는 지점이기에 `lastCalculatedAt`, `lastHeartbeatAt`을 현재 시간으로 업데이트하도록 했어요.
```java
// TimerFacade
TimerSession findTimerSession = fetchTimerSessionService.fetchTimerSession(userId, requestDto.targetDate());
if (findTimerSession == null || !Objects.equals(findTimerSession.getSelectedTask().getId(), requestDto.taskId())) {
    throw new NotFoundException(ErrorMessage.TIMER_SESSION_NOT_FOUND);
}

// TimerSession Domain
this.timerStatus = TimerStatus.RUNNING;
this.lastCalculatedAt = now;
this.lastHeartbeatAt = now;
```

### 3. 타이머 정지
- 타이머 정지 시, `TimerSession`을 조회하고 시작 때와 마찬가지로 유효성 검사를 추가했어요.
- 또한, 정지 API가 중복으로 호출될 것을 대비해 이미 정지 상태인 경우 그대로 리턴하도록 했어요.
- 마지막으로 계산되어 DB에 반영된 시점인 `lastCalculatedAt` 부터 현재 시점까지의 경과 시간을 계산하고, `TimerSession`과 `Timer` 엔티티에 경과 시간을 누적하도록 했어요.
- 또한 `TimerSession`에는 경과 시간을 계산해서 DB에 반영했기 때문에 `lastCalculatedAt` `lastHeartbeatAt`을 현재 시점으로 업데이트 했어요.
```java
// TimerFacade
TimerSession findTimerSession = fetchTimerSessionService.fetchTimerSession(userId, requestDto.targetDate());
if (findTimerSession == null || !Objects.equals(findTimerSession.getSelectedTask().getId(), requestDto.taskId())) {
    throw new NotFoundException(ErrorMessage.TIMER_SESSION_NOT_FOUND);
}
if (findTimerSession.getTimerStatus().equals(TimerStatus.PAUSED)) return;

int calculatedElapsedTime = calculateTimerSessionService.calculateElapsedTimeByLastCalculatedAt(findTimerSession, now);
timerSessionManager.pause(calculatedElapsedTime, findTimerSession, now);
timerManager.setElapsedTime(fetchTimerService.fetchByTaskIdAndTargetDate(requestDto.taskId(), requestDto.targetDate()), findTimerSession.getElapsedTime());

// TimerSession
if (this.timerStatus != TimerStatus.RUNNING || this.lastCalculatedAt == null) return; 
this.elapsedTime += calculateElapsedTime;
this.timerStatus = TimerStatus.PAUSED;
this.lastCalculatedAt = now;
this.lastHeartbeatAt = now;
```

### 4. 타이머 내 선택된 할일 조회 및 동기화
- 현재 `TimerSession`을 조회하고, 없다면 NFE를 발생시켜요. 
- 조회된 `TimerSession`이 실행중이라면, 경과 시간을 계산하고 `Timer`, `TimerSession`에 반영해요.
- 만약 정지 상태라면 경과 시간을 반영할 필요가 없으니 조회된 `TimerSession`을 DTO로 빌드해 리턴하도록 했어요.
```java
TimerSession findTimerSession = fetchTimerSessionService.fetchTimerSession(userId, targetDate);
if (findTimerSession == null) throw new NotFoundException(ErrorMessage.TIMER_SESSION_NOT_FOUND);
if (findTimerSession.getTimerStatus().equals(TimerStatus.RUNNING)) {
    int calculatedElapsedTime = calculateTimerSessionService.calculateElapsedTimeByLastCalculatedAt(findTimerSession, LocalDateTime.now());
    findTimerSession = timerSessionManager.handleCalledByClientFetch(calculatedElapsedTime, findTimerSession, now);
    timerManager.setElapsedTime(fetchTimerService.fetchByTaskIdAndTargetDate(findTimerSession.getSelectedTask().getId(), findTimerSession.getTargetDate()), findTimerSession.getElapsedTime());
}
return TimerDtos.TimerStatusResponse.from(findTimerSession);
```

### 5. 타이머 내 할일 선택
- 타이머 내 할일 선택의 의미는, 내부적으로 `TimerSession`의 정보를 업데이트하는 것을 의미해요.
- 요청으로 전달받은 `taskId`를 기반으로 DB에서 필요한 정보를 검색한 후, `TimerSession`을 업데이트하도록 했어요.
```java
User user = fetchUserService.fetchByUserId(userId);
Category findCategory = fetchCategoryService.fetchByUserIdAndTaskId(userId, requestDto.taskId());
Task selectedTask = fetchTaskService.fetchById(requestDto.taskId());
Timer timer = fetchTimerService.fetchOrCreateByTaskAndTargetDate(user, selectedTask, requestDto.targetDate());
TimerSession findTimerSession = fetchTimerSessionService.fetchTimerSession(userId, requestDto.targetDate());
if (findTimerSession == null) throw new NotFoundException(ErrorMessage.TIMER_SESSION_NOT_FOUND);
timerSessionManager.updateTimerSession(findTimerSession, findCategory.getName(), selectedTask, timer.getElapsedTime(), TimerStatus.PAUSED, requestDto.targetDate());
```

### 6. 타이머 실행 중에만 폴링으로 요청하는 하트비트 (client-side)
- 타이머 실행 중에는, 클라이언트에서 1분마다 폴링 방식으로 하트비트를 날려 사용자가 타이머를 실행 중이라고 알려줘요.
- 서버는 이 정보를 받아 해당 시점을 `lastHeartbeatAt`에 업데이트 해줘요. 이유는, 스케줄러를 통해 해당 시점을 이용하여 타이머 비활성화 또는 동기화를 진행해요.
```java
public void updateHeartbeat(LocalDateTime now) {
    if (this.timerStatus != TimerStatus.RUNNING) return;
    this.lastHeartbeatAt = now;
}
```

### 7. 타이머 비활성 세션은 중지시키고, 활성 세션은 동기화하는 서버 스케줄링 (server-side)
- 타이머가 비활성인지, 활성인지 판단하는 기준은 `lastHeartbeatAt`이 현재 스케줄링 시점으로부터 2분이 지났는가로 판단했어요. 1분마다 클라이언트의 요청에 의해 `lastHeartbeatAt`을 보내고 있기 때문이예요.
- 타이머 비활성 세션 또는 활성 세션 모두 마지막 계산 시점인 `lastCalculatedAt` 부터 현재 시점까지의 경과 시간을 `TimerSession`, `Timer`에 반영하도록 했어요.
- 활성 세션의 경우 `lastCalculatedAt`을 현재 시점으로 업데이트해요.
- 비활성 세션의 경우는 `lastCalculatedAt`, `lastHeartbeatAt`을 null로 설정하고, timerStatus를 정지상태로 변경하도록 했어요. 
```java
// 공통 로직 - 활성/비활성 판단
LocalDateTime cutoffTime = now.minus(INACTIVITY_THRESHOLD);
boolean isInactive = (lastHeartbeatTime == null || lastHeartbeatTime.isBefore(cutoffTime));

// 공통 로직  - 경과 시간 계산
Duration elapsedDuration = Duration.ZERO;
if (lastHeartbeatTime != null) {
    elapsedDuration = Duration.between(lastCalculatedAt, now);
} else {
    log.warn("[타이머 스케줄러] 비활성 세션 {}의 lastHeartbeatTime({})이 유효하지 않아 경과 시간 0으로 처리.", session.getId(), lastHeartbeatTime);
}
int deltaSeconds = (int) Math.max(0, elapsedDuration.toSeconds());

// 활성 세션의 경우
session.setElapsedTime(session.getElapsedTime() + deltaSeconds);
session.setLastCalculatedAt(calculationTime);
timerManager.addElapsedTime(timer, deltaSeconds);

// 비활성 세션의 경우
session.setElapsedTime(session.getElapsedTime() + deltaSeconds);
session.setTimerStatus(TimerStatus.PAUSED);
session.setLastCalculatedAt(null);
session.setLastHeartbeatAt(null);
timerManager.addElapsedTime(timer, deltaSeconds);
```

## ✅ Test Result
단일 사용자 및 멀티 사용자 환경으로 테스트 코드를 구성해 검증했어요.

## 💬 To Reviewers
