### PR TITLE
Refactor [#193] URL 정규화 관련 로직 전면 수정

### DIFF
--- a/morib/src/main/java/org/morib/server/domain/allowedSite/application/FetchSiteInfoService.java
+++ b/morib/src/main/java/org/morib/server/domain/allowedSite/application/FetchSiteInfoService.java
@@ -3,10 +3,5 @@ package org.morib.server.domain.allowedSite.application;
 import org.morib.server.api.allowGroupView.dto.AllowedSiteVo;
 
 public interface FetchSiteInfoService {
-    AllowedSiteVo fetch(String url);
-    String getTopDomain(String urlString);
-    String getTopDomainUrl(String urlString);
-    String getTopDomainWhenParsingFailed(String urlString);
-    String normalizeUrl(String url);
-    String getDomainExceptHost(String urlString);
+    AllowedSiteVo fetchSiteMetadataFromUrl(String url);
 }

--- a/morib/src/main/java/org/morib/server/domain/allowedSite/application/FetchSiteInfoServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/allowedSite/application/FetchSiteInfoServiceImpl.java
@@ -14,7 +14,7 @@ import java.net.URL;
 public class FetchSiteInfoServiceImpl implements FetchSiteInfoService {
 
     @Override
-    public AllowedSiteVo fetch(String url) {
+    public AllowedSiteVo fetchSiteMetadataFromUrl(String url) {
         try {
             Document doc = Jsoup.connect(url)
                     .userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
@@ -49,69 +49,10 @@ public class FetchSiteInfoServiceImpl implements FetchSiteInfoService {
 
             return AllowedSiteVo.of(favicon, siteName, pageName, url);
         }
-        catch (IOException e) {
-            String domain = UrlUtils.extractTopPrivateDomain(url);
-            return AllowedSiteVo.of("", domain, domain, url);
+        catch (Exception e) {
+            String normalizedUrl = UrlUtils.normalizeUrl(url);
+            return AllowedSiteVo.of("", normalizedUrl, normalizedUrl, url);
         }
     }
 
-    @Override
-    public String getTopDomain(String urlString) {
-        return UrlUtils.extractTopPrivateDomain(urlString);
-    }
-
-    @Override
-    public String getTopDomainUrl(String urlString) {
-        return UrlUtils.getTopDomainUrl(urlString);
-    }
-
-    @Override
-    public String getTopDomainWhenParsingFailed(String urlString) {
-        return UrlUtils.extractTopPrivateDomain(urlString);
-    }
-
-    @Override
-    public String normalizeUrl(String urlString) {
-        try {
-            // 프로토콜이 없으면 "https://" 추가
-            if (!urlString.matches("^(http://|https://).*")) {
-                urlString = "https://" + urlString;
-            }
-
-            URL url = new URL(urlString);
-
-            // 항상 https로 강제 (요구사항에 따라 변경 가능)
-            String scheme = "https";
-
-            // 호스트를 소문자로 변환하고 "www." 접두어 제거
-            String host = url.getHost().toLowerCase();
-            if (host.startsWith("www.")) {
-                host = host.substring(4);
-            }
-
-            // 포트: 기본 포트가 아니라면 포함 (예: https의 기본 포트 443)
-            int port = url.getPort();
-            String portPart = "";
-            if (port != -1 && port != (scheme.equals("https") ? 443 : 80)) {
-                portPart = ":" + port;
-            }
-
-            // 경로: "/"인 경우나 빈 문자열은 빈 문자열로 처리하고, 나머지 경우 끝의 "/" 제거
-            String path = url.getPath();
-            if (path == null || path.equals("/") || path.isEmpty()) {
-                path = "";
-            } else if (path.endsWith("/")) {
-                path = path.substring(0, path.length() - 1);
-            }
-
-            return scheme + "://" + host + portPart + path;
-        } catch (Exception e) {
-            return urlString;
-        }
-    }
-
-    @Override
-    public String getDomainExceptHost(String urlString) {
-        return UrlUtils.extractTopPrivateDomain(urlString);
-    }
 }

--- a/morib/src/main/java/org/morib/server/global/message/ErrorMessage.java
+++ b/morib/src/main/java/org/morib/server/global/message/ErrorMessage.java
@@ -14,6 +14,7 @@ public enum ErrorMessage {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "잘못된 형식입니다"),
     INVALID_URL(HttpStatus.BAD_REQUEST, "유효하지 않은 URL 형식입니다."),
+    URL_IS_EMPTY(HttpStatus.BAD_REQUEST, "URL이 비어있습니다."),
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, "유효하지 않은 이메일 형식입니다."),
     INVALID_TASK_IN_TODO(HttpStatus.BAD_REQUEST, "완료된 태스크는 할 일에 추가하거나 타이머를 실행할 수 없습니다."),
     CANNOT_ADD_YOURSELF(HttpStatus.BAD_REQUEST, "자기 자신을 친구로 추가할 수 없습니다."),


### PR DESCRIPTION
## 📍 Issue
- closes #193 

## ✨ Key Changes
계속해서 이슈가 발생했던 허용 서비스 관련 API의 URL 정규화 로직을 전면 수정했어요.

### 1. URL 정규화 로직 수정
- 기획 요구사항에 따라 URL 정규화 로직을 수정했어요.
- 기획 요구사항 

  > [유효성 검사]
•도메인 형식이 유효하지 않으면 (예: asdf, htp:/naver)
→ “유효한 도메인 형식이 아닙니다” 출력
•동일한 URL (host + pathname 기준)이 이미 등록된 경우
→ “이미 존재하는 서비스입니다” 출력
•입력값에 프로토콜이 없는 경우 자동으로 보정 (https:// 붙여서 파싱 시도)
•경로(/path)나 쿼리스트링(?query=123)은 있어도 됨, 비교를 위해 정규화 필요
[정규화]
1.프로토콜 제거
https://naver.com/page → [naver.com/page](http://naver.com/page)
http://naver.com/page → [naver.com/page](http://naver.com/page)
2.www. 제거
[www.naver.com/page](http://www.naver.com/page) → [naver.com/page](http://naver.com/page)
3.마지막 슬래시 / 제거
[naver.com/page/](http://naver.com/page/) → [naver.com/page](http://naver.com/page)
4.쿼리스트링 제거, pathname까지만 저장
[naver.com/page?foo=1&bar=2](http://naver.com/page?foo=1&bar=2) → [naver.com/page](http://naver.com/page)
[정규화 예시]
https://www.naver.com/page/ → [naver.com/page](http://naver.com/page)
http://blog.naver.com/PostView.naver?blogId=me → [blog.naver.com/PostView.naver](http://blog.naver.com/PostView.naver)
https://github.com/rkdals0203?tab=repos → [github.com/rkdals0203](http://github.com/rkdals0203)
https://www.example.com/ → [example.com](http://example.com/)
[naver.com](http://naver.com/) → [naver.com](http://naver.com/)
http://www.kakao.com/abc/ → [kakao.com/abc](http://kakao.com/abc)

- 로직 구성은 다음과 같아요.
1. 프로토콜 제거 `removeProtocol`
2. 쿼리 파라미터와 프래그먼트 제거 `removeQueryAndFragment`
3. 호스트와 경로 분리 `splitAndNormalizeHostPath`
4. 호스트 정규화 (www 제거) `normalizeHost`
5. 경로 정규화 (마지막 슬래시 제거) `normalizePath`
https://github.com/morib-in/Morib-Server-v2/blob/579ca4f8db091023e6ed4e00570689dca21345e3/morib/src/main/java/org/morib/server/global/common/util/UrlUtils.java#L60-L144

<br>

### 2. 상위 도메인 허용 로직 수정
- 상위 도메인 허용 로직을 서비스 레이어에서 유틸 클래스로 옮겼어요.
- 예외 발생 시, normalizeUrl로 URL 정규화해서 리턴하도록 했어요.
https://github.com/morib-in/Morib-Server-v2/blob/579ca4f8db091023e6ed4e00570689dca21345e3/morib/src/main/java/org/morib/server/global/common/util/UrlUtils.java#L17-L58

<br>

### 3. Jsoup을 이용한 HTML 파싱
- 기존 로직을 유지하되, 예외가 발생하면 URL 정규화 후 siteName, pageName에 넣어서 리턴하도록 했어요.
https://github.com/morib-in/Morib-Server-v2/blob/579ca4f8db091023e6ed4e00570689dca21345e3/morib/src/main/java/org/morib/server/domain/allowedSite/application/FetchSiteInfoServiceImpl.java#L52-L55


## ✅ Test Result


## 💬 To Reviewers
