### PR TITLE
Fix [#193] 파비콘 추출을 위해 원본 URL 보정 후 파비콘 추출하도록 변경

### DIFF
--- a/morib/src/main/java/org/morib/server/api/allowGroupView/facade/AllowedGroupViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/allowGroupView/facade/AllowedGroupViewFacade.java
@@ -152,7 +152,7 @@ public class AllowedGroupViewFacade {
         if (!Objects.isNull(findAllowedSite)) throw new DuplicateResourceException(ErrorMessage.DUPLICATE_RESOURCE);
 
         try {
-            AllowedSiteVo allowedSiteVo = fetchSiteInfoService.fetchSiteMetadataFromUrl(originalUrl);
+            AllowedSiteVo allowedSiteVo = fetchSiteInfoService.fetchSiteMetadataFromUrl(UrlUtils.normalizeUrlForFavicon(originalUrl));
             AllowedSiteVo voToSave = AllowedSiteVo.of(
                     allowedSiteVo.favicon(),
                     allowedSiteVo.siteName(),

--- a/morib/src/main/java/org/morib/server/global/common/util/UrlUtils.java
+++ b/morib/src/main/java/org/morib/server/global/common/util/UrlUtils.java
@@ -6,6 +6,7 @@ import org.morib.server.global.message.ErrorMessage;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.regex.Pattern;
 
 public class UrlUtils {
@@ -141,4 +142,44 @@ public class UrlUtils {
         }
         return path;
     }
+
+    public static String normalizeUrlForFavicon(String urlString) {
+        try {
+            // 프로토콜이 없으면 "https://" 추가
+            if (!urlString.matches("^(http://|https://).*")) {
+                urlString = "https://" + urlString;
+            }
+
+            URL url = new URL(urlString);
+
+            // 항상 https로 강제 (요구사항에 따라 변경 가능)
+            String scheme = "https";
+
+            // 호스트를 소문자로 변환하고 "www." 접두어 제거
+            String host = url.getHost().toLowerCase();
+            if (host.startsWith("www.")) {
+                host = host.substring(4);
+            }
+
+            // 포트: 기본 포트가 아니라면 포함 (예: https의 기본 포트 443)
+            int port = url.getPort();
+            String portPart = "";
+            if (port != -1 && port != 443) {
+                portPart = ":" + port;
+            }
+
+            // 경로: "/"인 경우나 빈 문자열은 빈 문자열로 처리하고, 나머지 경우 끝의 "/" 제거
+            String path = url.getPath();
+            if (path == null || path.equals("/") || path.isEmpty()) {
+                path = "";
+            } else if (path.endsWith("/")) {
+                path = path.substring(0, path.length() - 1);
+            }
+
+            return scheme + "://" + host + portPart + path;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
 }


### PR DESCRIPTION
## 📍 Issue
- closes #193 

## ✨ Key Changes
- 원본 url을 그대로 메타 데이터를 추출하는 함수에 넣으니 프로토콜이 없는 경우 파비콘이 추출되지 않는 이슈가 있었어요.
- 이를 해결하기 위해 메타 데이터를 추출할 때 원본 URL을 일반적인 형식으로 보정하도록 `UrlUtils`에 유틸 함수를 추가했어요.
```java
public static String normalizeUrlForFavicon(String urlString) {
    try {
        // 프로토콜이 없으면 "https://" 추가
        if (!urlString.matches("^(http://|https://).*")) {
            urlString = "https://" + urlString;
        }
  
        URL url = new URL(urlString);
  
        // 항상 https로 강제 (요구사항에 따라 변경 가능)
        String scheme = "https";
  
        // 호스트를 소문자로 변환하고 "www." 접두어 제거
        String host = url.getHost().toLowerCase();
        if (host.startsWith("www.")) {
            host = host.substring(4);
        }
  
        // 포트: 기본 포트가 아니라면 포함 (예: https의 기본 포트 443)
        int port = url.getPort();
        String portPart = "";
        if (port != -1 && port != 443) {
            portPart = ":" + port;
        }
  
        // 경로: "/"인 경우나 빈 문자열은 빈 문자열로 처리하고, 나머지 경우 끝의 "/" 제거
        String path = url.getPath();
        if (path == null || path.equals("/") || path.isEmpty()) {
            path = "";
        } else if (path.endsWith("/")) {
            path = path.substring(0, path.length() - 1);
        }
  
        return scheme + "://" + host + portPart + path;
    } catch (Exception e) {
        return null;
    }
  }
  ```
  
  ## ✅ Test Result
  
  
  ## 💬 To Reviewers
