### PR TITLE
Refactor [#207] 새벽 5시에 이전 날짜의 로그 파일 업로드하도록 수정

### DIFF
--- a/morib/src/main/java/org/morib/server/scheduler/S3LogUploader.java
+++ b/morib/src/main/java/org/morib/server/scheduler/S3LogUploader.java
@@ -11,13 +11,11 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
 import java.io.IOException;
-import java.nio.file.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 @Slf4j
 @Service
@@ -32,75 +30,50 @@ public class S3LogUploader {
     @Value("${cloud.aws.s3.log-path-prefix}")
     private String logPathPrefix;
 
-    private static final Pattern LOG_FILE_PATTERN = Pattern.compile("error\\.(\\d{4}-\\d{2}-\\d{2})\\.log");
-    private static final DateTimeFormatter DATE_FORMATTER_YYYY_MM_DD = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-    private static final DateTimeFormatter S3_PATH_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy/MM/dd");
+    @Scheduled(cron = "0 0 5 * * *", zone = "Asia/Seoul")
+    public void uploadYesterdayLogErrorLogToS3() {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        String datePattern = "yyyy-MM-dd";
+        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern(datePattern);
+        String formattedYesterday = yesterday.format(dateFormatter);
 
-    // 임시 설정: 백로그 처리를 위해 5분마다 실행
-    // 원래 설정: @Scheduled(cron = "0 0 5 * * *", zone = "Asia/Seoul")
-    @Scheduled(cron = "0 */5 * * * *", zone = "Asia/Seoul")
-    public void uploadLogFilesToS3() { // 메서드 이름도 임시로 변경
-        Path logsDirectory = Paths.get("./logs");
+        String logFileName = "error." + formattedYesterday + ".log";
+        Path localLogFilePath = Paths.get("./logs/", logFileName);
 
-        if (!Files.isDirectory(logsDirectory)) {
-            log.warn("Logs directory not found: {}", logsDirectory.toAbsolutePath());
-            return;
-        }
+        log.info("Checking for yesterday's log file: {}", localLogFilePath);
 
-        log.info("Scanning log directory: {}", logsDirectory.toAbsolutePath());
+        if (Files.exists(localLogFilePath)) {
+            String s3ObjectKey = buildS3ObjectKey(yesterday, logFileName);
+            log.info("Found log file {}. Uploading to S3 bucket '{}' with key '{}'", logFileName, bucketName, s3ObjectKey);
+            try {
+                PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(s3ObjectKey)
+                        .build();
 
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(logsDirectory, "error.*.log")) {
-            for (Path localLogFilePath : stream) {
-                if (Files.isRegularFile(localLogFilePath)) {
-                    String logFileName = localLogFilePath.getFileName().toString();
-                    Matcher matcher = LOG_FILE_PATTERN.matcher(logFileName);
+                s3Client.putObject(putObjectRequest, RequestBody.fromFile(localLogFilePath));
 
-                    if (matcher.matches()) {
-                        String dateString = matcher.group(1);
-                        try {
-                            LocalDate logDate = LocalDate.parse(dateString, DATE_FORMATTER_YYYY_MM_DD);
-                            // --- S3 업로드 로직 시작 ---
-                            String s3ObjectKey = buildS3ObjectKey(logDate, logFileName);
-                            log.info("Found log file {}. Uploading to S3 bucket '{}' with key '{}'", logFileName, bucketName, s3ObjectKey);
-                            try {
-                                PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                                        .bucket(bucketName)
-                                        .key(s3ObjectKey)
-                                        .build();
+                log.info("Successfully uploaded log file {} to S3.", logFileName);
 
-                                s3Client.putObject(putObjectRequest, RequestBody.fromFile(localLogFilePath));
+                // Optional: Uncomment to delete local file after successful upload
+                // deleteLocalFile(localLogFilePath);
 
-                                log.info("Successfully uploaded log file {} to S3.", logFileName);
-
-                                // 선택 사항: 업로드 성공 후 로컬 파일 삭제 (백로그 처리 시에는 주의해서 사용)
-                                // deleteLocalFile(localLogFilePath);
-
-                            } catch (S3Exception e) {
-                                log.error("Error uploading log file {} to S3: {}", logFileName, e.awsErrorDetails().errorMessage(), e);
-                            } catch (Exception e) {
-                                log.error("An unexpected error occurred during S3 upload of {}: {}", logFileName, e.getMessage(), e);
-                            }
-                            // --- S3 업로드 로직 끝 ---
-                        } catch (DateTimeParseException e) {
-                            log.warn("Could not parse date from log file name: {}", logFileName);
-                        }
-                    } else {
-                        log.warn("Filename {} does not match expected pattern.", logFileName);
-                    }
-                }
+            } catch (S3Exception e) {
+                log.error("Error uploading log file {} to S3: {}", logFileName, e.awsErrorDetails().errorMessage(), e);
+            } catch (Exception e) {
+                log.error("An unexpected error occurred during S3 upload of {}: {}", logFileName, e.getMessage(), e);
             }
-            log.info("Finished scanning log directory.");
-        } catch (IOException e) {
-            log.error("Error reading log directory: {}", logsDirectory.toAbsolutePath(), e);
+        } else {
+            log.info("Log file {} not found locally, skipping upload.", logFileName);
         }
     }
 
     private String buildS3ObjectKey(LocalDate date, String logFileName) {
-        // 예: logs/2024/07/29/error.2024-07-29.log
+        DateTimeFormatter s3PathDateFormatter = DateTimeFormatter.ofPattern("yyyy/MM/dd");
         return logPathPrefix +
-                date.format(S3_PATH_DATE_FORMATTER) +
-                "/" +
-                logFileName;
+               date.format(s3PathDateFormatter) +
+               "/" +
+               logFileName;
     }
 
     private void deleteLocalFile(Path filePath) {


### PR DESCRIPTION
## 📍 Issue
- closes #207 

## ✨ Key Changes
테스트 용도의 코드를 삭제하고, 새벽 5시마다 이전 날짜의 로그 파일을 s3에 업로드하도록 수정했어요.

- 객체의 이름을 날짜와 yaml에서 주입한 log path를 이용해 생성하도록 했어요.
https://github.com/morib-in/Morib-Server-v2/blob/863121a363715a2c112829103f3eb250a2f7f201/morib/src/main/java/org/morib/server/scheduler/S3LogUploader.java#L71-L77

- s3에 업로드를 성공한 로그 파일을 로컬 머신에서 삭제하도록 했어요.
https://github.com/morib-in/Morib-Server-v2/blob/863121a363715a2c112829103f3eb250a2f7f201/morib/src/main/java/org/morib/server/scheduler/S3LogUploader.java#L79-L86

- 새벽 5시마다 스케줄링을 통해 로그 파일을 s3에 업로드하도록 했어요.
https://github.com/morib-in/Morib-Server-v2/blob/863121a363715a2c112829103f3eb250a2f7f201/morib/src/main/java/org/morib/server/scheduler/S3LogUploader.java#L33-L69

## ✅ Test Result


## 💬 To Reviewers
