### PR TITLE
QA [#210] 최종 QA 반영

### DIFF
--- a/morib/src/main/java/org/morib/server/api/allowGroupView/facade/AllowedGroupViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/allowGroupView/facade/AllowedGroupViewFacade.java
@@ -246,7 +246,7 @@ public class AllowedGroupViewFacade {
         String topDomain = UrlUtils.getTopDomain(siteUrl);
         if (Objects.isNull(topDomain) || topDomain.isEmpty() || topDomain.equals("localhost")) return;
         List<AllowedSite> findAllowedSites = fetchAllowedSiteService.fetchByDomainContaining(allowedGroupId, topDomain);
-        if (findAllowedSites.size() > 1) mergeToOne(topDomain, findAllowedSites);
+        if (findAllowedSites.size() > 1) mergeToOne(UrlUtils.getTopDomainUrl(siteUrl), findAllowedSites);
     }
 
     public void mergeToOne(String topDomainUrl, List<AllowedSite> targetAllowedSites) {

--- a/morib/src/main/java/org/morib/server/api/allowGroupView/facade/AllowedGroupViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/allowGroupView/facade/AllowedGroupViewFacade.java
@@ -258,10 +258,10 @@ public class AllowedGroupViewFacade {
         }
     }
 
-    public Map<InterestArea, List<RecommendSiteResponseDto>> fetchRecommendSitesOnboard() {
+    public Map<String, List<RecommendSiteResponseDto>> fetchRecommendSitesOnboard() {
         return fetchRecommendSiteService.fetchAll().stream()
                 .collect(Collectors.groupingBy(
-                        RecommendSite::getInterestArea,
+                        recommendSite -> recommendSite.getInterestArea().getInterestArea(),
                         Collectors.mapping(RecommendSiteResponseDto::from, Collectors.toList())
                 ));
     }

--- a/morib/src/main/java/org/morib/server/api/loginView/controller/UserAuthController.java
+++ b/morib/src/main/java/org/morib/server/api/loginView/controller/UserAuthController.java
@@ -2,6 +2,7 @@ package org.morib.server.api.loginView.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.morib.server.api.loginView.dto.UserReissueResponseDto;
+import org.morib.server.api.loginView.dto.UserReissueTmpRequestDto;
 import org.morib.server.api.loginView.facade.UserAuthFacade;
 import org.morib.server.domain.user.application.dto.ReissueTokenServiceDto;
 import org.morib.server.global.common.BaseResponse;
@@ -32,6 +33,13 @@ public class UserAuthController {
         return ResponseEntity.status(SuccessMessage.SUCCESS.getHttpStatus())
                 .header(HttpHeaders.SET_COOKIE, buildCookieForRefreshToken(dto.refreshToken()).toString())
                 .body(BaseResponse.of(SuccessMessage.SUCCESS, UserReissueResponseDto.of(dto.accessToken())));
+    }
+
+    @PostMapping("/users/reissue/tmp")
+    public ResponseEntity<BaseResponse<?>> reissueTemporaryApi(
+            @RequestBody UserReissueTmpRequestDto userReissueTmpRequestDto
+    ) {
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS, userAuthFacade.reissue(userReissueTmpRequestDto.refreshToken()));
     }
 
     @DeleteMapping("/users/withdraw")

--- a/morib/src/main/java/org/morib/server/api/loginView/dto/UserReissueRequestDto.java
+++ b/morib/src/main/java/org/morib/server/api/loginView/dto/UserReissueRequestDto.java
@@ -1,6 +1,0 @@
-package org.morib.server.api.loginView.dto;
-
-public record UserReissueRequestDto (
-        Long userId
-) {
-}

--- a/morib/src/main/java/org/morib/server/api/loginView/dto/UserReissueTmpRequestDto.java
+++ b/morib/src/main/java/org/morib/server/api/loginView/dto/UserReissueTmpRequestDto.java
@@ -1,0 +1,6 @@
+package org.morib.server.api.loginView.dto;
+
+public record UserReissueTmpRequestDto(
+        String refreshToken
+) {
+}

--- a/morib/src/main/java/org/morib/server/api/timerView/controller/TimerViewController.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/controller/TimerViewController.java
@@ -54,7 +54,7 @@ public class TimerViewController {
 
     @PostMapping("/timer/select")
     public ResponseEntity<BaseResponse<?>> selectTimerInfo(@AuthenticationPrincipal CustomUserDetails customUserDetails,
-                                                           @Valid @RequestBody TimerRequestDto requestDto) { // @Valid 추가 가능
+                                                           @Valid @RequestBody TimerRequestDto requestDto) {
         Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
         timerViewFacade.selectTimerInfo(userId, requestDto);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
@@ -67,27 +67,6 @@ public class TimerViewController {
         timerViewFacade.handleHeartbeat(userId, targetDate);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
-
-    // ----------------------------------------------------------------------------------- //
-//    @PostMapping("/timer/sync")
-//    public ResponseEntity<BaseResponse<?>> saveTimerSession(@AuthenticationPrincipal CustomUserDetails customUserDetails,
-//                                                            @Valid @RequestBody SaveTimerSessionRequestDto saveTimerSessionRequestDto) {
-//        Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
-//        timerViewFacade.saveTimerSession(userId, saveTimerSessionRequestDto);
-//        return ApiResponseUtil.success(SuccessMessage.SUCCESS);
-//    }
-//
-//    @GetMapping("/timer/ping")
-//    public ResponseEntity<BaseResponse<?>> timerPing(@AuthenticationPrincipal CustomUserDetails customUserDetails,
-//                                                            @RequestParam Long taskId,
-//                                                            @RequestParam int elapsedTime,
-//                                                            @RequestParam TimerStatus timerStatus,
-//                                                            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate) {
-//        Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
-//        SaveTimerSessionRequestDto saveTimerSessionRequestDto = SaveTimerSessionRequestDto.of(taskId, elapsedTime, timerStatus, targetDate);
-//        timerViewFacade.saveTimerSession(userId, saveTimerSessionRequestDto);
-//        return ApiResponseUtil.success(SuccessMessage.SUCCESS);
-//    }
 
     @GetMapping("/timer/todo-card")
     public ResponseEntity<BaseResponse<?>> getTodoCards(@AuthenticationPrincipal CustomUserDetails customUserDetails,

--- a/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
@@ -72,6 +72,7 @@ public class TimerViewFacade {
         if (findTimerSession == null || !Objects.equals(findTimerSession.getSelectedTask().getId(), requestDto.taskId())) {
             throw new NotFoundException(ErrorMessage.TIMER_SESSION_NOT_FOUND);
         }
+        if (Boolean.TRUE.equals(findTimerSession.getSelectedTask().getIsComplete())) throw new InvalidStateException(ErrorMessage.FAILED_TO_START_COMPLETED_TASK);
         timerSessionManager.run(findTimerSession, now);
     }
 

--- a/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java
@@ -33,6 +33,7 @@ import org.morib.server.domain.todo.infra.Todo;
 import org.morib.server.domain.user.application.service.FetchUserService;
 import org.morib.server.domain.user.infra.User;
 import org.morib.server.global.common.HealthCheckController;
+import org.morib.server.global.exception.InvalidStateException;
 import org.morib.server.global.exception.NotFoundException;
 import org.morib.server.global.message.ErrorMessage;
 import org.springframework.transaction.annotation.Transactional;
@@ -121,24 +122,6 @@ public class TimerViewFacade {
         TimerSession findTimerSession = fetchTimerSessionService.fetchTimerSession(userId, targetDate);
         timerSessionManager.handleHeartbeat(findTimerSession, now);
     }
-
-
-//
-
-    // ----------------------------------------------------------------------
-//    @Transactional
-//    public void saveTimerSession(Long userId, SaveTimerSessionRequestDto saveTimerSessionRequestDto) {
-//        TimerSession findTimerSession = fetchTimerSessionService.fetchTimerSession(userId, saveTimerSessionRequestDto.targetDate());
-//        Category findCategory = fetchCategoryService.fetchByUserIdAndTaskId(userId, saveTimerSessionRequestDto.taskId());
-//        Timer findTimer = fetchTimerService.fetchByTaskIdAndTargetDate(saveTimerSessionRequestDto.taskId(), saveTimerSessionRequestDto.targetDate());
-//        timerManager.setElapsedTime(findTimer, saveTimerSessionRequestDto.elapsedTime());
-//
-//        if (findTimerSession == null) {
-//            createTimerSessionService.create(userId, findCategory.getName(), saveTimerSessionRequestDto.taskId(), saveTimerSessionRequestDto.elapsedTime(), saveTimerSessionRequestDto.timerStatus(), saveTimerSessionRequestDto.targetDate());
-//        } else {
-//            timerSessionManager.updateTimerSession(findTimerSession, saveTimerSessionRequestDto);
-//        }
-//    }
 
     @Transactional
     public TodoCardResponseDto fetchTodoCard(Long userId, LocalDate targetDate) {

--- a/morib/src/main/java/org/morib/server/global/exception/GlobalExceptionHandler.java
+++ b/morib/src/main/java/org/morib/server/global/exception/GlobalExceptionHandler.java
@@ -119,5 +119,11 @@ public class GlobalExceptionHandler {
         log.error(">>> handle: MissingServletRequestParameterException, parameter name: {}", e.getParameterName());
         return ApiResponseUtil.failure(ErrorMessage.valueOf(e.getMessage()));
     }
+
+    @ExceptionHandler(InvalidStateException.class)
+    protected ResponseEntity<BaseResponse<?>> handleInvalidStateException(final InvalidStateException e) {
+        log.error(">>> handle: InvalidStateException ", e);
+        return ApiResponseUtil.failure(e.getErrorMessage());
+    }
 }
 

--- a/morib/src/main/java/org/morib/server/global/exception/InvalidStateException.java
+++ b/morib/src/main/java/org/morib/server/global/exception/InvalidStateException.java
@@ -1,0 +1,9 @@
+package org.morib.server.global.exception;
+
+import org.morib.server.global.message.ErrorMessage;
+
+public class InvalidStateException extends BusinessException {
+    public InvalidStateException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/morib/src/main/java/org/morib/server/global/message/ErrorMessage.java
+++ b/morib/src/main/java/org/morib/server/global/message/ErrorMessage.java
@@ -22,6 +22,7 @@ public enum ErrorMessage {
     TIMER_SESSION_NOT_FOUND(HttpStatus.BAD_REQUEST, "타이머 세션을 찾을 수 없습니다."),
     MISSING_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "필수 요청 파라미터가 누락되었습니다."),
     TARGET_DATE_IS_NOT_PRESENT(HttpStatus.BAD_REQUEST, "targetDate 날짜는 오늘이어야 합니다."),
+    FAILED_TO_START_COMPLETED_TASK(HttpStatus.BAD_REQUEST, "완료된 할 일은 시작할 수 없습니다."),
     /**
      * 401 Unauthorized
      */


### PR DESCRIPTION
## 📍 Issue
- closes #210 

## ✨ Key Changes
최종 QA 사항들을 반영했어요.

### 1. reissue api query parameter 방식으로 임시 변경
- 클라이언트에서 일렉트론 도입으로 인한 요구사항에 따라, 토큰 재발급 api 요청 파라미터를 쿠키가 아닌 쿼리 파라미터 방식으로 임시 추가했어요.
https://github.com/morib-in/Morib-Server-v2/blob/0fb189389c648e6f929a472185692ac0ddc18b2d/morib/src/main/java/org/morib/server/api/loginView/controller/UserAuthController.java#L38-L43

### 2. 상위 도메인 허용 api 오류 해결
- 상위 도메인 허용 시, 합치는 과정은 잘 진행되었지만 최종적으로 DB에 업데이트되는 레코드가 도메인이 그대로 메타 데이터 추출 파라미터로 들어가 제대로 파싱이 안되는 이슈가 있었어요.
- 요청 파라미터로 들어온 원본 Url의 상위 도메인 Full Url을 추출하는 유틸 함수를 추가했고, 해당 함수로 얻은 상위 도메인의 Full Url을 활용해 메타 데이터를 추출하도록 변경했어요.
https://github.com/morib-in/Morib-Server-v2/blob/0fb189389c648e6f929a472185692ac0ddc18b2d/morib/src/main/java/org/morib/server/api/allowGroupView/facade/AllowedGroupViewFacade.java#L249
https://github.com/morib-in/Morib-Server-v2/blob/0fb189389c648e6f929a472185692ac0ddc18b2d/morib/src/main/java/org/morib/server/global/common/util/UrlUtils.java#L18-L71

### 3. 타이머 내 완료된 할 일은 타이머 실행할 수 없도록 예외처리
- 타이머 내 완료된 할 일은 타이머를 실행할 수 없도록 처리하기 위해, `findTimerSession`의 `selectedTask` complete 여부를 확인해 예외를 발생시키도록 했어요.
https://github.com/morib-in/Morib-Server-v2/blob/0fb189389c648e6f929a472185692ac0ddc18b2d/morib/src/main/java/org/morib/server/api/timerView/facade/TimerViewFacade.java#L76

### 4. 온보딩 추천 서비스 조회 api InterestArea Enum 자체가 아닌 값으로 응답하도록 수정
- 클라이언트의 요청에 따라 온보딩 추천 서비스 조회 시, 배열의 key로 지정되어있던 `InterestArea`를 `getInterestArea()`로 값을 추출해 응답하도록 변경했어요.
https://github.com/morib-in/Morib-Server-v2/blob/0fb189389c648e6f929a472185692ac0ddc18b2d/morib/src/main/java/org/morib/server/api/loginView/controller/UserAuthController.java#L38-L43

## ✅ Test Result


## 💬 To Reviewers
