### PR TITLE
Fix [#210] 상위 도메인 허용 에러 해결

### DIFF
--- a/morib/src/main/java/org/morib/server/api/allowGroupView/facade/AllowedGroupViewFacade.java
+++ b/morib/src/main/java/org/morib/server/api/allowGroupView/facade/AllowedGroupViewFacade.java
@@ -243,6 +243,7 @@ public class AllowedGroupViewFacade {
 
     @Transactional
     public void mergeToTopDomain(Long allowedGroupId, String siteUrl) {
+        if (fetchAllowedSiteService.fetchBySiteUrlAndAllowedGroupId(siteUrl, allowedGroupId) == null) throw new NotFoundException(ErrorMessage.NOT_FOUND);
         String topDomain = UrlUtils.getTopDomain(siteUrl);
         if (Objects.isNull(topDomain) || topDomain.isEmpty() || topDomain.equals("localhost")) return;
         List<AllowedSite> findAllowedSites = fetchAllowedSiteService.fetchByDomainContaining(allowedGroupId, topDomain);

--- a/morib/src/main/java/org/morib/server/domain/allowedSite/AllowedSiteManager.java
+++ b/morib/src/main/java/org/morib/server/domain/allowedSite/AllowedSiteManager.java
@@ -14,7 +14,7 @@ public class AllowedSiteManager {
     }
 
     @Transactional
-    public void updateAllowedSiteInfo(AllowedSite allowedSite, AllowedSiteVo allowedSiteVo) {
-        allowedSite.updateAllowedSiteInfo(allowedSiteVo.favicon(), allowedSiteVo.siteName(), allowedSiteVo.pageName(), allowedSiteVo.siteUrl());
+    public void updateAllowedSiteInfo(AllowedSite allowedSite, AllowedSiteVo allowedSiteVo, String siteUrl) {
+        allowedSite.updateAllowedSiteInfo(allowedSiteVo.favicon(), allowedSiteVo.siteName(), allowedSiteVo.pageName(), siteUrl);
     }
 }


### PR DESCRIPTION
## 📍 Issue
- closes #210 

## ✨ Key Changes
상위 도메인 허용 API시, 합칠 URL이 1개인 경우 합쳐지지 않는 이슈가 있었어요. 2개 이상인 경우에만 합쳐질 수 있다고 잘못 생각했던 것이 문제였습니다.
- size가 2 이상이 아닌 비어있지 않은 경우 하도록 변경
  ```java
  if (!findAllowedSites.isEmpty()) mergeToOne(UrlUtils.getTopDomainUrl(siteUrl), findAllowedSites);
  ``` 

- 상위 도메인 허용 api 파라미터에 전달된 siteUrl이 존재하지 않는 경우가 핸들링 되어있지 않아 추가했어요.
    ```java
    if (fetchAllowedSiteService.fetchBySiteUrlAndAllowedGroupId(siteUrl, allowedGroupId) == null) throw new NotFoundException(ErrorMessage.NOT_FOUND);
    ```

- 상위 도메인 허용 시 최종적으로 생성되는 레코드의 siteUrl이 정규화되지 않고 DB에 추가되는 이슈가 있어, 최종적으로 merge 후 정규화해 DB 업데이트하도록 변경했어요.
    ```java
    allowedSiteManager.updateAllowedSiteInfo(baseAllowedSite, fetchSiteInfoService.fetchSiteMetadataFromUrl(topDomainUrl), UrlUtils.normalizeUrl(topDomainUrl));
    ```

## ✅ Test Result


## 💬 To Reviewers
