### PR TITLE
Feat [#215] 랜딩 페이지에서 윈도우 사용자 이메일 수집하는 api 추가 

### DIFF
--- a/morib/src/main/java/org/morib/server/api/loginView/controller/UserAuthController.java
+++ b/morib/src/main/java/org/morib/server/api/loginView/controller/UserAuthController.java
@@ -3,6 +3,7 @@ package org.morib.server.api.loginView.controller;
 import lombok.RequiredArgsConstructor;
 import org.morib.server.api.loginView.dto.UserReissueResponseDto;
 import org.morib.server.api.loginView.dto.UserReissueTmpRequestDto;
+import org.morib.server.api.loginView.dto.WaitingUserWindowRequestDto;
 import org.morib.server.api.loginView.facade.UserAuthFacade;
 import org.morib.server.domain.user.application.dto.ReissueTokenServiceDto;
 import org.morib.server.global.common.BaseResponse;
@@ -46,6 +47,12 @@ public class UserAuthController {
     public ResponseEntity<BaseResponse<?>> withdraw(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
         Long userId = principalHandler.getUserIdFromUserDetails(customUserDetails);
         userAuthFacade.withdraw(userId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS);
+    }
+
+    @PostMapping("/waiting/windows")
+    public ResponseEntity<BaseResponse<?>> createWaitingUserWindow(@RequestBody WaitingUserWindowRequestDto waitingUserWindowRequestDto) {
+        userAuthFacade.createWaitingUserWindow(waitingUserWindowRequestDto.email());
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 

--- a/morib/src/main/java/org/morib/server/api/loginView/dto/WaitingUserWindowRequestDto.java
+++ b/morib/src/main/java/org/morib/server/api/loginView/dto/WaitingUserWindowRequestDto.java
@@ -1,0 +1,6 @@
+package org.morib.server.api.loginView.dto;
+
+public record WaitingUserWindowRequestDto(
+        String email
+) {
+}

--- a/morib/src/main/java/org/morib/server/api/loginView/facade/UserAuthFacade.java
+++ b/morib/src/main/java/org/morib/server/api/loginView/facade/UserAuthFacade.java
@@ -8,6 +8,7 @@ import org.morib.server.domain.relationship.infra.Relationship;
 import org.morib.server.domain.relationship.infra.RelationshipRepository;
 import org.morib.server.domain.user.UserManager;
 import org.morib.server.domain.user.application.dto.ReissueTokenServiceDto;
+import org.morib.server.domain.user.application.service.CreateWaitingUserWindowService;
 import org.morib.server.domain.user.application.service.DeleteUserService;
 import org.morib.server.domain.user.application.service.FetchUserService;
 import org.morib.server.domain.user.application.service.ReissueTokenService;
@@ -27,9 +28,9 @@ public class UserAuthFacade {
     private final DeleteUserService deleteUserService;
     private final UserManager userManager;
     private final CustomOAuth2UserService customOAuth2UserService;
-    private final DeleteRelationshipService deleteRelationshipService;
     private final FetchRelationshipService fetchRelationshipService;
     private final RelationshipRepository relationshipRepository;
+    private final CreateWaitingUserWindowService createWaitingUserWindowService;
 
     public ReissueTokenServiceDto reissue(String refreshToken) {
         return reissueTokenService.reissue(refreshToken);
@@ -53,5 +54,9 @@ public class UserAuthFacade {
         deleteUserService.delete(userId);
     }
 
+    @Transactional
+    public void createWaitingUserWindow(String email) {
+        createWaitingUserWindowService.createWaitingUserWindow(email);
+    }
 
 }

--- a/morib/src/main/java/org/morib/server/domain/user/application/service/CreateWaitingUserWindowService.java
+++ b/morib/src/main/java/org/morib/server/domain/user/application/service/CreateWaitingUserWindowService.java
@@ -1,0 +1,5 @@
+package org.morib.server.domain.user.application.service;
+
+public interface CreateWaitingUserWindowService {
+    void createWaitingUserWindow(String email);
+}

--- a/morib/src/main/java/org/morib/server/domain/user/application/service/CreateWaitingUserWindowServiceImpl.java
+++ b/morib/src/main/java/org/morib/server/domain/user/application/service/CreateWaitingUserWindowServiceImpl.java
@@ -1,0 +1,18 @@
+package org.morib.server.domain.user.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.morib.server.domain.user.infra.WaitingUserWindow;
+import org.morib.server.domain.user.infra.WaitingUserWindowRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CreateWaitingUserWindowServiceImpl implements CreateWaitingUserWindowService{
+
+    private final WaitingUserWindowRepository waitingUserWindowRepository;
+
+    @Override
+    public void createWaitingUserWindow(String email) {
+        waitingUserWindowRepository.save(WaitingUserWindow.create(email));
+    }
+}

--- a/morib/src/main/java/org/morib/server/domain/user/infra/WaitingUserWindow.java
+++ b/morib/src/main/java/org/morib/server/domain/user/infra/WaitingUserWindow.java
@@ -1,0 +1,24 @@
+package org.morib.server.domain.user.infra;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.morib.server.global.common.BaseTimeEntity;
+
+@Entity
+@Getter
+@Builder(access = AccessLevel.PUBLIC)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class WaitingUserWindow extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "waiting_user_window_id")
+    private Long id;
+    private String email;
+
+    public static WaitingUserWindow create(String email) {
+        return WaitingUserWindow.builder()
+                .email(email)
+                .build();
+    }
+}

--- a/morib/src/main/java/org/morib/server/domain/user/infra/WaitingUserWindowRepository.java
+++ b/morib/src/main/java/org/morib/server/domain/user/infra/WaitingUserWindowRepository.java
@@ -1,0 +1,6 @@
+package org.morib.server.domain.user.infra;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WaitingUserWindowRepository extends JpaRepository<WaitingUserWindow, Long> {
+}

--- a/morib/src/main/java/org/morib/server/global/config/SecurityConfig.java
+++ b/morib/src/main/java/org/morib/server/global/config/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
                 });
 
         http.authorizeHttpRequests((auth) -> auth
-                .requestMatchers("/","/css/**","/images/**","/js/**","/favicon.ico", "/profile", "/health,", "/actuator/**", "/error", "/api/v2/s3/**").permitAll()
+                .requestMatchers("/","/css/**","/images/**","/js/**","/favicon.ico", "/profile", "/health,", "/actuator/**", "/error", "/api/v2/s3/**", "/api/v2/waiting/windows").permitAll()
                 .anyRequest().authenticated()
         );
         http.addFilterAfter(jwtAuthenticationFilter(), LogoutFilter.class);


### PR DESCRIPTION
## 📍 Issue
- closes #215 

## ✨ Key Changes
- 랜딩 페이지에서 윈도우 사용자의 이메일을 수집하는 api를 추가했어요.
- 테이블 구성은 단순하게 `BaseTImeEntity`와 `id`, `email`로만 간결하게 구성했어요.
- `SecurityConfig`에 필터 검증 통과로 해당 api를 추가해 토큰 없이 서버에 들어오도록 했어요.

## ✅ Test Result


## 💬 To Reviewers
