### PR TITLE
Feat [#249] 애플 소셜 초기 로그인 시 이름 저장하도록 진행

### DIFF
--- a/morib/src/main/java/org/morib/server/domain/user/UserManager.java
+++ b/morib/src/main/java/org/morib/server/domain/user/UserManager.java
@@ -1,10 +1,15 @@
 package org.morib.server.domain.user;
 
+import java.util.Objects;
+
 import org.morib.server.annotation.Manager;
 import org.morib.server.domain.user.application.dto.UpdateUserProfileServiceDto;
 import org.morib.server.domain.user.infra.User;
 import org.morib.server.domain.user.infra.type.InterestArea;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Manager
 public class UserManager {
 
@@ -26,5 +31,15 @@ public class UserManager {
 
     public void completeOnboarding(User findUser) {
         findUser.completeOnboarding();
+    }
+
+
+    public void updateUserName(User findUser, String fullName) {
+        if(Objects.isNull(fullName) || findUser.isOnboardingCompleted()){
+            log.info("Full name is null or is already onboarding");
+            return;
+        }
+        log.info("Full name was {}", fullName);
+        findUser.updateUserName(fullName);
     }
 }

--- a/morib/src/main/java/org/morib/server/domain/user/infra/User.java
+++ b/morib/src/main/java/org/morib/server/domain/user/infra/User.java
@@ -93,4 +93,8 @@ public class User extends BaseTimeEntity {
     public void completeOnboarding() {
         this.isOnboardingCompleted = true;
     }
+
+    public void updateUserName(String fullName) {
+        this.name = fullName;
+    }
 }

--- a/morib/src/main/java/org/morib/server/global/oauth2/apple/dto/AppleResponseName.java
+++ b/morib/src/main/java/org/morib/server/global/oauth2/apple/dto/AppleResponseName.java
@@ -1,0 +1,13 @@
+package org.morib.server.global.oauth2.apple.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AppleResponseName {
+	private String firstName;
+	private String lastName;
+}

--- a/morib/src/main/java/org/morib/server/global/oauth2/apple/dto/AppleUserInfoDto.java
+++ b/morib/src/main/java/org/morib/server/global/oauth2/apple/dto/AppleUserInfoDto.java
@@ -1,0 +1,17 @@
+package org.morib.server.global.oauth2.apple.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AppleUserInfoDto {
+	private AppleResponseName name;
+	private String email;
+
+	public static String fullName(AppleUserInfoDto dto) {
+		return dto.getName().getLastName()  + dto.getName().getFirstName();
+	}
+}


### PR DESCRIPTION
## 📍 Issue
- closes #249

## ✨ Key Changes

### 🍎 Apple 소셜 로그인 초기 회원가입 시 이름 저장 기능 구현
- **Apple 전용 DTO 클래스 추가**:
  - `AppleResponseName.java`: Apple에서 제공하는 이름 정보 매핑
  - `AppleUserInfoDto.java`: Apple 사용자 정보 통합 관리

### 👤 사용자 엔티티 및 관리 개선  
- **User.java**: Apple 이름 정보 저장을 위한 필드/메서드 추가
- **UserManager.java**: Apple 사용자 이름 업데이트 로직 구현 (15줄 추가)

### 🔧 OAuth2 인증 플로우 개선
- **OAuth2LoginSuccessHandler.java**: Apple 초기 로그인 시 이름 정보 추출 및 저장 로직 통합 (25줄 추가, 7줄 수정)

## ✅ Test Result
- ✅ Apple 소셜 로그인 시 사용자 이름 정상 저장
- ✅ 기존 Apple 로그인 사용자 영향 없음  
- ✅ Google 소셜 로그인 기능 정상 유지
- ✅ 사용자 프로필 정보 완성도 향상

## 💬 To Reviewers
- **총 5개 파일 변경** (67줄 추가, 7줄 삭제)
- Apple OAuth2에서 제공하는 `name` 정보를 초기 회원가입 시에만 저장하는 로직
- Apple의 개인정보 보호 정책에 따라 이름 정보는 최초 1회만 제공되므로 이를 놓치지 않도록 구현
- 기존 Apple 로그인 사용자와 새로운 사용자 모두 호환 가능하도록 설계
- DTO 패턴 적용으로 Apple 전용 데이터 구조 안전하게 관리